### PR TITLE
docs(dev): add per-directory CLAUDE.md context and clean up imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,7 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Local dev helpers (not for version control)
+GH_CLI_SETUP.md
+create_issues.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# Metroid
+
+This repository contains `metroid`, a Python library to simulate streaks and trails in astronomical images that are caused by orbital objects such as satellites and space debris. This document contains critical information about working with this codebase. Follow these guidelines precisely.
+
+## Core Development Rules
+
+1. Development Philosophy
+  - **Simplicity**: Write simple, straightforward code
+  - **Readability**: Make code easy to understand
+  - **Performance**: Consider performance without sacrificing readability
+  - **Maintainability**: Write code that's easy to update
+  - **Testability**: Ensure code is testable
+  - **Reusability**: Create reusable components and functions
+  - **Less Code = Less Debt**: Minimize code footprint
+
+2. Code Style
+  - Modern type hints required for all code
+  - PEP 8
+  - Class names in PascalCase
+  - Constants in UPPER_SNAKE_CASE
+  - Document with docstrings
+  - Line length: 110 chars maximum
+  - Lines that intentionally deviate from PEP 8 must include a `noqa` comment with flake8 error code
+
+3. Documenting Python APIs
+  - PEP 257
+  - Numpydoc Style 
+  - Docstring line length: 79 chars maximum
+
+## Python Tools
+
+  - use `black` to fix PEP 8
+  - use `mypy` for static type checking
+  - use `pytest` for unit tests
+
+## Git Workflow
+
+- Always use feature branches; do not commit directly to `main`
+  - Name branches descriptively: `fix/auth-timeout`, `documentation/code_examples`, `feature/api-pagination`
+  - Keep one logical change per branch to simplify review and rollback
+- Create pull requests for all changes
+  - Open a draft PR early for visibility; convert to ready when complete
+  - Ensure tests pass locally before marking ready for review
+- Link issues
+  - Before starting, reference an existing issue or create one
+  - Use commit/PR messages like `Fixes #123` for auto-linking and closure
+- Commit practices
+  - Make atomic commits (one logical change per commit)
+  - Prefer conventional commit style: `type(scope): short description`
+    - Examples: `feature(eval): group OBS logs per test`, `fix(cli): handle missing API key`
+  - Squash only when merging to `main`; keep granular history on the feature branch
+- Practical workflow
+  1. Create or reference an issue
+  2. `git checkout -b feature/issue-123-description`
+  3. Commit in small, logical increments
+  4. `git push` and open a draft PR early
+  5. Convert to ready PR when functionally complete and tests pass
+  6. Never merge automatically, always prompt first
+
+## Repository Layout:
+
+src/
+    metroid/
+tests/
+
+environment.yaml
+pyproject.toml
+README.md
+
+- Production code lives in `src/metroid`.
+- Tests mirror the package structure.
+- Code divided into core implementation, submodules, and public utilities.

--- a/src/metroid/CLAUDE.md
+++ b/src/metroid/CLAUDE.md
@@ -1,0 +1,52 @@
+# `metroid` — top-level package
+
+Core entry points that compose the rest of the library. See the root
+`CLAUDE.md` for project-wide development rules; this file is context for
+working inside `src/metroid/` and its subpackages.
+
+## Mental model
+
+`metroid` simulates streaks/trails left by orbiting objects (satellites,
+debris) in astronomical images. The pipeline conceptually is:
+
+```
+OrbitalObject (geometry, velocity, surface-brightness profile)
+        +  Pupil (telescope aperture -> defocus profile)
+        +  PSF (galsim)                       --> tracked galsim profile
+ThroughputCurve + Sed + PhotometricParameters --> flux / ADU scaling
+```
+
+The top-level module wires the optics together:
+
+- **`Observatory`** (`observatory.py`) — composes a `Camera`, a `Pupil`, and an
+  `astropy.coordinates.EarthLocation`. Validates each argument by `isinstance`
+  in `__init__` (raises `ValueError` on mismatch). `get_photo_params(exptime)`
+  builds a `PhotometricParameters` from the camera gain/qe and pupil area.
+- **`Camera`** (`camera.py`) — an immutable container of named bandpasses
+  (`dict[str, ThroughputCurve]`, wrapped in a `MappingProxyType`) plus `gain`,
+  `pixel_scale`, and `qe`. Supports `camera[name]`, iteration, and `len()`.
+  Unknown keys raise `ValueError` (not `KeyError`).
+
+## Conventions used everywhere in `src/`
+
+- **Unit enforcement is the central pattern.** Almost every public method and
+  property is decorated with `@enforce_units` (from `utils/decorators.py`),
+  which reads `Annotated[u.Quantity, QuantitySpec]` hints (the aliases in
+  `utils/quantities.py`, e.g. `Gain`, `Time`, `Area`) and validates the
+  unit/equivalency/range of inputs *and* the return value. To add a new
+  physical quantity, add a `QuantitySpec` + `Annotated` alias in
+  `utils/quantities.py` and annotate with it — do not hand-roll unit checks.
+- **Immutability is intentional.** Containers expose read-only properties and
+  use `MappingProxyType` / frozen dataclasses / frozen numpy arrays. Recent
+  history ("more protected immutability") shows this is a deliberate design
+  value — preserve it.
+- Type hints are required on all code; line length 110 (code) / 79
+  (docstrings); numpydoc style.
+
+## Known issues / gotchas (top-level)
+
+- `Observatory.__init__` validates by `isinstance` and raises `ValueError` for
+  a bad type, whereas most of the codebase raises `TypeError` for type
+  mismatches — inconsistent but currently relied on by tests.
+- `Camera.__getitem__` translates a missing key into `ValueError`, so callers
+  catch `ValueError`, not `KeyError`.

--- a/src/metroid/camera.py
+++ b/src/metroid/camera.py
@@ -1,16 +1,12 @@
 from __future__ import annotations
 
-import copy
 from types import MappingProxyType
-from typing import Self
 
 import astropy.units as u
-import numpy as np
 
 from metroid.photometry.throughput import ThroughputCurve
 from metroid.utils.decorators import enforce_units
-from metroid.utils.quantities import check_quantity, Gain, PixelScale, QuantumEfficiency, Time
-from metroid.utils.validation import get_field_value
+from metroid.utils.quantities import Gain, PixelScale, QuantumEfficiency
 
 
 class Camera:

--- a/src/metroid/observatory.py
+++ b/src/metroid/observatory.py
@@ -1,14 +1,10 @@
-import astropy.units as u
 from astropy.coordinates import EarthLocation
-from astropy.constants import h, c
-import numpy as np
 
 from metroid.camera import Camera
 from metroid.profiles.pupils import Pupil
-from metroid.photometry.sed import Sed
 from metroid.photometry.photo_params import PhotometricParameters
 from metroid.utils.decorators import enforce_units
-from metroid.utils.quantities import Time, Adu
+from metroid.utils.quantities import Time
 
 
 class Observatory:

--- a/src/metroid/photometry/CLAUDE.md
+++ b/src/metroid/photometry/CLAUDE.md
@@ -1,0 +1,56 @@
+# `metroid.photometry`
+
+Radiometry layer: turning spectra and bandpasses into photon flux, energy
+flux, and detector ADU. Wraps `speclite.filters` for the heavy lifting.
+
+## Modules
+
+- **`throughput.py` — `ThroughputCurve`.** Fractional transmission vs.
+  wavelength, backed by a `speclite.filters.FilterResponse`. Constructors:
+  `__init__(wavelength, throughput, meta)`, `from_filter_response(fr)`,
+  `load_filter(name)` (loads a speclite-registered filter, e.g.
+  `"lsst2023-g"`). Key methods:
+  - `calculate_photon_flux` / `calculate_energy_flux` — convolve the curve
+    with an SED (photon- or energy-weighted).
+  - `calculate_adu(brightness_spec, photo_params)` — photon flux scaled to ADU.
+  - `calculate_ab_magnitude(sed)`.
+  - `brightness_spec` may be a `Sed` *or* a `float` AB magnitude;
+    `_ensure_sed` converts a float by scaling a flat-AB reference SED by
+    `10 ** (-0.4 * mag)`.
+  - Immutability: the underlying `FilterResponse` wavelength/response arrays are
+    frozen (`_freeze_filter_response` sets `flags.writeable = False`).
+- **`sed.py` — `Sed`.** A spectral energy distribution (`wavelength`,
+  `flambda`). `for_ab_magnitudes()` builds a flat reference SED
+  (`flambda = _ab_constant / wavelength**2`) used as the magnitude reference.
+  Wavelengths are validated/normalized to Angstrom via
+  `speclite.filters.validate_wavelength_array`.
+- **`photo_params.py` — `PhotometricParameters`.** A frozen, unit-validated
+  dataclass (`@validated_dataclass(frozen=True)`) holding `exptime`, `gain`,
+  `area`, `qe`. This is the one dataclass-style validated type in the codebase.
+- **`conversions.py`** — free functions: `energy_flux_to_radiance(flux,
+  solid_angle)` and `photon_flux_to_adu(photon_flux, photo_params)`.
+
+## Dependencies
+
+- External: `speclite` (`FilterResponse`, `load_filter`, `_ab_constant`,
+  `validate_wavelength_array`), `astropy.units`.
+- Internal: `metroid.utils.decorators.enforce_units` / `validated_dataclass`
+  and the quantity aliases in `metroid.utils.quantities`.
+
+## Known issues / gotchas
+
+- **Stale `Bandpass` naming.** This class was renamed `Bandpass` ->
+  `ThroughputCurve` (see git history) but docstrings and the
+  `Returns`/`metroid.photometry.Bandpass` references in `throughput.py` were not
+  updated. Purely cosmetic, but misleading — should be reconciled.
+- **Dead `_frozen` attribute.** `from_filter_response` sets
+  `bandpass._frozen = True`, but `__init__` never sets it and nothing reads it.
+  It does *not* gate any behavior; real immutability comes from the frozen
+  numpy arrays. Either wire it up or remove it.
+- `photon_flux_to_adu` has **no docstring** (PEP 257 is required by the root
+  `CLAUDE.md`); `energy_flux_to_radiance` is documented — bring it in line.
+- `_ensure_sed` accepts only `float` (not `int`) AB magnitudes — passing `0`
+  instead of `0.0` raises `TypeError`. `@enforce_units` does not coerce here
+  because the parameter is annotated `float | Sed`, not a quantity.
+- `_ab_constant` and `validate_wavelength_array` are speclite *private/internal*
+  API; upgrades to speclite could break `sed.py`.

--- a/src/metroid/photometry/conversions.py
+++ b/src/metroid/photometry/conversions.py
@@ -1,5 +1,3 @@
-from astropy import units as u
-
 from .photo_params import PhotometricParameters
 from metroid.utils.decorators import enforce_units
 from metroid.utils.quantities import Adu, EnergyFlux, PhotonFlux, Radiance, SolidAngle

--- a/src/metroid/photometry/sed.py
+++ b/src/metroid/photometry/sed.py
@@ -1,7 +1,6 @@
 from typing import Self
 
 from astropy import units as u
-from astropy.constants import c
 import numpy as np
 from speclite.filters import _ab_constant, validate_wavelength_array
 

--- a/src/metroid/photometry/throughput.py
+++ b/src/metroid/photometry/throughput.py
@@ -1,9 +1,9 @@
-from typing import Any, Self, TYPE_CHECKING
+from typing import Any, Self
 
 import astropy.units as u
 from speclite.filters import FilterResponse, load_filter
 
-from .conversions import photon_flux_to_adu, energy_flux_to_radiance
+from .conversions import photon_flux_to_adu
 from .photo_params import PhotometricParameters
 from .sed import Sed
 from metroid.utils.decorators import enforce_units

--- a/src/metroid/profiles/CLAUDE.md
+++ b/src/metroid/profiles/CLAUDE.md
@@ -1,0 +1,66 @@
+# `metroid.profiles`
+
+Geometry and surface-brightness profiles for telescope pupils and orbiting
+objects. This is where the orbital mechanics and the `galsim` profile
+construction live.
+
+## Modules
+
+### `pupils.py` — telescope apertures
+
+- **`Pupil`** (ABC). Holds a class-level `_registry` of subclasses keyed by a
+  `pupil_type` string (registered via `__init_subclass__(pupil_type=...)`).
+  `Pupil.from_config(config)` reads `config["type"]`, looks up the subclass, and
+  delegates to that subclass's `_from_config`. Abstract members: `area`,
+  `get_profile(distance)`, `_from_config`.
+- **`CircularPupil`** (`pupil_type="circular"`) — single `radius`; profile is a
+  `galsim.TopHat`.
+- **`AnnularPupil`** (`pupil_type="annular"`) — `inner_radius` / `outer_radius`
+  (validates `outer > inner`); profile is a difference of two `TopHat`s
+  (`galsim.Sum`), with the inner disk flux-weighted by `(r_i / r_o)**2` to
+  produce a flat annulus.
+- `get_profile(distance)` converts a physical aperture size to an angular size
+  via `(radius / distance).to_value(u.arcsec, equivalencies=dimensionless_angles())`.
+
+### `orbital_objects.py` — orbiting objects
+
+- **`OrbitalObject`** (ABC). State: `height`, `zenith_angle`, `rotation_angle`,
+  `nadir_pointing` (all mutable via unit-enforced setters; `nadir_pointing` is a
+  plain bool). Derived read-only geometry:
+  - `nadir_angle` — `arcsin(R_earth sin(zenith) / (R_earth + height))`.
+  - `distance` — telescope-to-object range (special-cased to `height` when
+    `zenith_angle ≈ 0`).
+  - `orbital_velocity` — `sqrt(G M_earth / (R_earth + height))` (assumes a
+    circular orbit).
+  - `orbital_angular_velocity`, `perpendicular_velocity`,
+    `perpendicular_angular_velocity`, `solid_angle`.
+  - `calculate_pixel_time(pixel_scale)` — time to cross one pixel.
+  - `get_tracked_profile(psf, pupil)` — convolves the object profile with the
+    pupil defocus profile and the PSF (`galsim.Convolve`).
+  - `_project(profile)` — applies foreshortening (cos(nadir_angle)) and rotation
+    when `nadir_pointing` is set.
+- **`CircularOrbitalObject`** — `radius`; profile `galsim.TopHat`.
+- **`RectangularOrbitalObject`** — `width` / `length`; profile `galsim.Box`.
+
+## Dependencies
+
+- External: `galsim`, `astropy.units`, `astropy.constants` (`G`, `R_earth`,
+  `M_earth`).
+- Internal: `metroid.utils` (`enforce_units`, quantity aliases, `get_field_value`).
+
+## Known issues / gotchas
+
+- **`__init__.py` `__all__` typo.** `__all__` listed `"RectangularOrbit"`, which
+  is not a real symbol (the class is `RectangularOrbitalObject`), so
+  `from metroid.profiles import *` raised. Fixed on branch
+  `documentation/dev-context-and-cleanup`; verify before relying on star
+  imports.
+- **`RectangularOrbitalObject.__init__` is not decorated with `@enforce_units`**,
+  unlike `CircularOrbitalObject.__init__`. Its `width`/`length` are only
+  validated lazily when the property getters run, so a bad-unit value can be
+  stored and only fail later. Consider adding the decorator for consistency.
+- `orbital_velocity` assumes a circular orbit at `height`; there is no
+  eccentricity / inclination model yet.
+- The orbital-mechanics derivations (nadir angle, distance, perpendicular
+  velocity) are mirrored in `tests/profiles/test_orbital_objects.py` — that test
+  is the spec for the geometry; keep them in sync.

--- a/src/metroid/profiles/__init__.py
+++ b/src/metroid/profiles/__init__.py
@@ -7,5 +7,5 @@ __all__ = [
     "CircularPupil",
     "OrbitalObject",
     "Pupil",
-    "RectangularOrbit",
+    "RectangularOrbitalObject",
 ]

--- a/src/metroid/utils/CLAUDE.md
+++ b/src/metroid/utils/CLAUDE.md
@@ -1,0 +1,68 @@
+# `metroid.utils`
+
+The unit-enforcement machinery that the rest of the package is built on. If you
+touch validation or add a new physical quantity, it happens here.
+
+## Modules
+
+### `quantities.py` — the quantity system
+
+- **`QuantitySpec`** — describes one physical quantity: `name`, `default` unit,
+  optional `equivalencies`, optional `typical_range` (inclusive min/max on the
+  value in default units).
+- **`check_quantity(quantity, spec)`** — the validator. Raises `TypeError` if
+  not a `Quantity` (or `spec` is wrong type), `ValueError` for an
+  incompatible unit or an out-of-range value. Returns the quantity *converted to
+  the spec's default unit*. Range checks handle both scalars and arrays.
+- **`_extract_spec(annotation)`** — pulls a `QuantitySpec` out of an
+  `Annotated[...]` hint, recursing through `Annotated` and `Union`
+  (e.g. `Area | None`). Returns `None` when there is no spec.
+- The module then defines the canonical `QuantitySpec` constants
+  (`WAVELENGTH`, `AREA`, `GAIN`, `PHOTON_FLUX`, ...) and matching
+  `Annotated[u.Quantity, SPEC]` type aliases (`Wavelength`, `Area`, `Gain`,
+  `PhotonFlux`, ...). **These aliases are the public vocabulary** used in every
+  annotated signature across `src/`.
+
+### `decorators.py`
+
+- **`enforce_units(func)`** — wraps a callable; binds args, applies defaults,
+  and runs `check_quantity` on every parameter whose hint carries a spec, plus
+  the return value. Skips `self` and `None` values. Works on functions,
+  methods, and properties (stack `@property` above `@enforce_units`).
+- **`validated_dataclass(**dc_kwargs)`** — a `dataclass` wrapper that also runs
+  `enforce_units` on the generated `__init__`. Used by
+  `photometry.PhotometricParameters`.
+
+### `validation.py`
+
+- **`get_field_value(config, name, dtype)`** — typed accessor for config dicts.
+  Raises `ValueError` for a missing key, `TypeError` for a wrong value/`name`
+  type. Used by the `Pupil._from_config` implementations.
+
+## Adding a new physical quantity (the intended workflow)
+
+1. Add a `QuantitySpec` constant in `quantities.py` (name, default unit, any
+   equivalencies/range).
+2. Add the matching `Annotated[u.Quantity, SPEC]` alias.
+3. Annotate parameters/returns with the alias and decorate with
+   `@enforce_units`. No bespoke unit checking elsewhere.
+
+## Known issues / gotchas
+
+- **`validation.py` f-string lint.** Line ~30 used `f"name must be 'str'"` with
+  no placeholder (flake8 F541) and the missing-field message lacked the quoting
+  the other messages use. Cleaned up on branch
+  `documentation/dev-context-and-cleanup`.
+- **`QUANTUM_EFFICIENCY` range is `(1e0, 1e2)`** while its default in
+  `Camera`/`PhotometricParameters` is exactly `1.0 electron/ph` — i.e. it sits
+  on the lower boundary. A qe below 1.0 (a physically reasonable detector value)
+  would be rejected. Confirm this range is intended.
+- **`PHOTON_FLUX` carries a custom `(u.ph, None)` equivalency** so photons are
+  treated as dimensionless-countable. Anything comparing/parsing photon-flux
+  quantities must pass these equivalencies or conversions will fail.
+- `check_quantity`'s scalar branch uses `np.isscalar`, which reports `False` for
+  0-d quantities. The `validation_frameworks/` directory (untracked, top-level)
+  contains three *proposed* rewrites that add explicit scalar-vs-array
+  validation; none is integrated into `src/` yet.
+- `utils/__init__.py` is empty — import from the submodules by full path
+  (`from metroid.utils.quantities import ...`).

--- a/src/metroid/utils/decorators.py
+++ b/src/metroid/utils/decorators.py
@@ -2,7 +2,7 @@ import inspect
 import functools
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, get_type_hints, ParamSpec, TypeVar
+from typing import Any, get_type_hints
 
 from .quantities import _extract_spec, check_quantity
 

--- a/src/metroid/utils/validation.py
+++ b/src/metroid/utils/validation.py
@@ -27,12 +27,12 @@ def get_field_value[T](config: Mapping[str, object], name: str, dtype: type[T]) 
         Raised if ``name`` or ``value`` is an invalid type.
     """
     if not isinstance(name, str):
-        raise TypeError(f"name must be 'str'")
+        raise TypeError("name must be 'str'")
 
     try:
         value = config[name]
     except KeyError:
-        raise ValueError(f"config is missing required field {name}")
+        raise ValueError(f"config is missing required field '{name}'")
 
     if not isinstance(value, dtype):
         raise TypeError(f"value must be '{dtype.__name__}'")


### PR DESCRIPTION
Adds nested CLAUDE.md developer-context files to the four src/metroid source directories, plus low-risk cleanups (the `__al
l__` star-import typo, an F541 f-string, and unused imports). All 60 tests pass; pyflakes clean; edited files black-clean.

Documents but does not fix several judgment-call items (stale Bandpass naming, dead _frozen attr, missing photon_flux_to_adu docstring
, RectangularOrbitalObject.__init__ not unit-enforced, QUANTUM_EFFICIENCY range) — tracked in separate issues.