### PR TITLE
Scalar/array shape axis for the quantity type-hint framework (Formulation A)

### DIFF
--- a/src/metroid/CLAUDE.md
+++ b/src/metroid/CLAUDE.md
@@ -31,10 +31,11 @@ The top-level module wires the optics together:
 
 - **Unit enforcement is the central pattern.** Almost every public method and
   property is decorated with `@enforce_units` (from `utils/decorators.py`),
-  which reads `Annotated[u.Quantity, QuantitySpec]` hints (the aliases in
-  `utils/quantities.py`, e.g. `Gain`, `Time`, `Area`) and validates the
-  unit/equivalency/range of inputs *and* the return value. To add a new
-  physical quantity, add a `QuantitySpec` + `Annotated` alias in
+  which reads the generic quantity aliases in `utils/quantities.py`
+  (e.g. `Gain`, `Time`, `Area`; subscript for shape, e.g. `Time[Scalar]`) and
+  validates the unit/equivalency/constraints *and* shape of inputs *and* the
+  return value. To add a new physical quantity, add a `Spec(...)` constant plus
+  a `type NewQuantity[Sh] = Annotated[u.Quantity, NEW_QUANTITY, Sh]` alias in
   `utils/quantities.py` and annotate with it — do not hand-roll unit checks.
 - **Immutability is intentional.** Containers expose read-only properties and
   use `MappingProxyType` / frozen dataclasses / frozen numpy arrays. Recent

--- a/src/metroid/utils/CLAUDE.md
+++ b/src/metroid/utils/CLAUDE.md
@@ -7,28 +7,48 @@ touch validation or add a new physical quantity, it happens here.
 
 ### `quantities.py` — the quantity system
 
-- **`QuantitySpec`** — describes one physical quantity: `name`, `default` unit,
-  optional `equivalencies`, optional `typical_range` (inclusive min/max on the
-  value in default units).
-- **`check_quantity(quantity, spec)`** — the validator. Raises `TypeError` if
-  not a `Quantity` (or `spec` is wrong type), `ValueError` for an
-  incompatible unit or an out-of-range value. Returns the quantity *converted to
-  the spec's default unit*. Range checks handle both scalars and arrays.
-- **`_extract_spec(annotation)`** — pulls a `QuantitySpec` out of an
-  `Annotated[...]` hint, recursing through `Annotated` and `Union`
-  (e.g. `Area | None`). Returns `None` when there is no spec.
+The spec is a small **constraint algebra**: a physical identity plus a list of
+pluggable checks. Scalar-vs-array is a *separate* axis (a computer
+representation, not physics) supplied at the annotation site, not stored in the
+spec.
+
+- **`QuantitySpec`** — a frozen dataclass describing one physical quantity:
+  `name`, `default` unit, `equivalencies`, and an ordered
+  `constraints: tuple[Constraint, ...]`. No range/shape fields.
+- **`Constraint` protocol** — any object with
+  `check(quantity, name) -> str | None` (message or `None`). Built-ins:
+  `Range(vmin, vmax)`, `Finite`. Add a new kind by writing a ~4-line frozen
+  dataclass; `check_quantity` never changes.
+- **`Spec` builder** — fluent, terse: `Spec("gain", u.electron/u.adu).ranged(0.1, 100).build()`.
+- **Shape axis** — `ShapeKind` protocol with singletons `SCALAR` / `ARRAY` /
+  `ANY_SHAPE`, and marker *types* `Scalar` / `Array` / `AnyShape` used as the
+  generic subscript (`Time[Scalar]`).
+- **`check_quantity(quantity, spec, shape=ANY_SHAPE)`** — the validator.
+  Raises `TypeError` (not a `Quantity`/`spec`), `ValueError` (incompatible
+  unit). Converts to the default unit, then runs all value-level constraints
+  **and** the shape check, aggregating every failure into one
+  `QuantityValidationError` (a `ValueError` subclass — existing
+  `except ValueError` still catches it).
+- **`_extract_spec(annotation)`** — returns a `(spec, shape)` tuple. Handles a
+  bare generic alias (`Time` → any shape), a subscripted alias
+  (`Time[Scalar]`), a raw `Annotated`, and unions (`Time[Scalar] | None`,
+  both `typing.Union` and PEP 604 `|`). `(None, ANY_SHAPE)` when no spec.
 - The module then defines the canonical `QuantitySpec` constants
-  (`WAVELENGTH`, `AREA`, `GAIN`, `PHOTON_FLUX`, ...) and matching
-  `Annotated[u.Quantity, SPEC]` type aliases (`Wavelength`, `Area`, `Gain`,
-  `PhotonFlux`, ...). **These aliases are the public vocabulary** used in every
-  annotated signature across `src/`.
+  (`WAVELENGTH`, `AREA`, `GAIN`, `PHOTON_FLUX`, ...) and matching **generic**
+  type aliases via the `type` statement
+  (`type Time[Sh] = Annotated[u.Quantity, TIME, Sh]`, etc.). **These aliases
+  are the public vocabulary** used in every annotated signature across `src/`.
+  Use the bare alias (`Area`) for any-shape, or `Area[Scalar]` / `Area[Array]`
+  to restrict.
 
 ### `decorators.py`
 
 - **`enforce_units(func)`** — wraps a callable; binds args, applies defaults,
   and runs `check_quantity` on every parameter whose hint carries a spec, plus
-  the return value. Skips `self` and `None` values. Works on functions,
-  methods, and properties (stack `@property` above `@enforce_units`).
+  the return value. Uses the `(spec, shape)` pair from `_extract_spec`, so a
+  `Time[Scalar]` hint enforces shape too. Skips `self` and `None` values. Works
+  on functions, methods, and properties (stack `@property` above
+  `@enforce_units`).
 - **`validated_dataclass(**dc_kwargs)`** — a `dataclass` wrapper that also runs
   `enforce_units` on the generated `__init__`. Used by
   `photometry.PhotometricParameters`.
@@ -41,11 +61,18 @@ touch validation or add a new physical quantity, it happens here.
 
 ## Adding a new physical quantity (the intended workflow)
 
-1. Add a `QuantitySpec` constant in `quantities.py` (name, default unit, any
-   equivalencies/range).
-2. Add the matching `Annotated[u.Quantity, SPEC]` alias.
-3. Annotate parameters/returns with the alias and decorate with
+1. Add a `QuantitySpec` constant in `quantities.py` with the `Spec` builder
+   (name, default unit, any equivalencies, any value-level constraints such as
+   `.ranged(...)` / `.finite()`).
+2. Add the matching generic alias:
+   `type NewQuantity[Sh] = Annotated[u.Quantity, NEW_QUANTITY, Sh]`.
+3. Annotate parameters/returns with the alias (`NewQuantity` for any shape, or
+   `NewQuantity[Scalar]` / `NewQuantity[Array]`) and decorate with
    `@enforce_units`. No bespoke unit checking elsewhere.
+
+To add a new *kind of value-level check*, write a small frozen dataclass with a
+`check(quantity, name) -> str | None` method and attach it via the builder's
+`.with_constraint(...)`; `check_quantity` needs no changes.
 
 ## Known issues / gotchas
 
@@ -53,16 +80,21 @@ touch validation or add a new physical quantity, it happens here.
   no placeholder (flake8 F541) and the missing-field message lacked the quoting
   the other messages use. Cleaned up on branch
   `documentation/dev-context-and-cleanup`.
-- **`QUANTUM_EFFICIENCY` range is `(1e0, 1e2)`** while its default in
-  `Camera`/`PhotometricParameters` is exactly `1.0 electron/ph` — i.e. it sits
-  on the lower boundary. A qe below 1.0 (a physically reasonable detector value)
-  would be rejected. Confirm this range is intended.
+- **Range limits were dropped during the constraint-algebra refactor.** No
+  catalogue spec currently carries a `Range`; ranges (including the old
+  `QUANTUM_EFFICIENCY` `(1e0, 1e2)` that rejected a physically reasonable
+  `qe < 1.0`) will be reworked per physical quantity on a case-by-case basis.
+  Re-add them with `Spec(...).ranged(vmin, vmax)`.
 - **`PHOTON_FLUX` carries a custom `(u.ph, None)` equivalency** so photons are
   treated as dimensionless-countable. Anything comparing/parsing photon-flux
   quantities must pass these equivalencies or conversions will fail.
-- `check_quantity`'s scalar branch uses `np.isscalar`, which reports `False` for
-  0-d quantities. The `validation_frameworks/` directory (untracked, top-level)
-  contains three *proposed* rewrites that add explicit scalar-vs-array
-  validation; none is integrated into `src/` yet.
+- **Shape markers come in two flavours**, easy to mix up: the *types* `Scalar`
+  / `Array` / `AnyShape` are only ever used as the generic subscript
+  (`Time[Scalar]`); the *singletons* `SCALAR` / `ARRAY` / `ANY_SHAPE` are the
+  `ShapeKind` instances passed to `check_quantity` directly. `_extract_spec`
+  maps the former to the latter.
+- **Generic aliases require Python 3.12+** (`type` statement / PEP 695). The
+  repo runs 3.13, and `enforce_units` / `validated_dataclass` already use PEP
+  695 generics, so this is consistent with the codebase.
 - `utils/__init__.py` is empty — import from the submodules by full path
   (`from metroid.utils.quantities import ...`).

--- a/src/metroid/utils/decorators.py
+++ b/src/metroid/utils/decorators.py
@@ -32,14 +32,14 @@ def enforce_units[**P, R](func: Callable[P, R]) -> Callable[P, R]:
             if name in ["self"]:
                 continue
 
-            spec = _extract_spec(hints.get(name))
+            spec, shape = _extract_spec(hints.get(name))
             if spec and value is not None:
-                bound.arguments[name] = check_quantity(value, spec)
+                bound.arguments[name] = check_quantity(value, spec, shape)
 
         result = func(*bound.args, **bound.kwargs)
-        return_spec = _extract_spec(hints.get("return"))
+        return_spec, return_shape = _extract_spec(hints.get("return"))
         if return_spec and result is not None:
-            result = check_quantity(result, return_spec)
+            result = check_quantity(result, return_spec, return_shape)
 
         return result
 

--- a/src/metroid/utils/quantities.py
+++ b/src/metroid/utils/quantities.py
@@ -1,26 +1,148 @@
-from typing import Annotated, Any, Union, get_args, get_origin
+"""Physical quantity specifications and runtime validation.
+
+A :class:`QuantitySpec` reduces a physical quantity to its essential
+identity - a name, a canonical unit, and allowed equivalencies - plus an
+ordered list of pluggable :class:`Constraint` objects. Validation converts
+to canonical units once and then runs every value-level constraint,
+aggregating all failures into a single :class:`QuantityValidationError`.
+
+New kinds of value-level check are added by writing a small constraint
+class; the core :func:`check_quantity` validator never changes. The fluent
+:class:`Spec` builder keeps the catalogue declarations terse.
+"""
+
+from dataclasses import dataclass, field, replace
+from typing import Annotated, Any, Protocol, Union, get_args, get_origin, runtime_checkable
 
 import astropy.units as u
 import numpy as np
 
 
-class QuantitySpec:
-    """A quantity specification."""
+class QuantityValidationError(ValueError):
+    """All value-level validation failures for a single quantity, aggregated.
 
-    def __init__(
-        self,
-        name: str,
-        default: u.Unit,
-        equivalencies: list | None = None,
-        typical_range: tuple[float, float] | None = None,
-    ):
+    Subclasses :class:`ValueError`, so existing ``except ValueError``
+    handlers continue to catch it.
+
+    Parameters
+    ----------
+    name : `str`
+        The physical quantity name.
+    problems : `list` [`str`]
+        One human-readable message per failed constraint.
+    """
+
+    def __init__(self, name: str, problems: list[str]):
         self.name = name
-        self.default = default
-        self.equivalencies = equivalencies or []
-        self.typical_range = typical_range
+        self.problems = problems
+        super().__init__(f"{name} failed validation: {'; '.join(problems)}")
+
+
+@runtime_checkable
+class Constraint(Protocol):
+    """A single, self-describing value-level check.
+
+    A constraint inspects an already-unit-converted quantity and returns an
+    error message if it is violated, or ``None`` if satisfied.
+    """
+
+    def check(self, quantity: u.Quantity, name: str) -> str | None:
+        """Return an error message, or ``None`` if the constraint holds."""
+        ...
+
+
+@dataclass(frozen=True)
+class Range:
+    """Require every value to lie within an inclusive range.
+
+    Parameters
+    ----------
+    vmin, vmax : `float`
+        The inclusive bounds, in the spec's canonical unit.
+    """
+
+    vmin: float
+    vmax: float
+
+    def check(self, quantity: u.Quantity, name: str) -> str | None:
+        value = quantity.value
+        if not np.all((value >= self.vmin) & (value <= self.vmax)):
+            return f"has values outside range {self.vmin}-{self.vmax}"
+        return None
+
+
+@dataclass(frozen=True)
+class Finite:
+    """Require every value to be finite (no NaN or inf)."""
+
+    def check(self, quantity: u.Quantity, name: str) -> str | None:
+        if not np.all(np.isfinite(quantity.value)):
+            return "contains non-finite values (NaN or inf)"
+        return None
+
+
+@dataclass(frozen=True)
+class QuantitySpec:
+    """A physical quantity specification - unit identity plus constraints.
+
+    Prefer the fluent :class:`Spec` builder for declarations.
+
+    Parameters
+    ----------
+    name : `str`
+        The physical quantity name.
+    default : `astropy.units.Unit`
+        The canonical unit.
+    equivalencies : `list`, optional
+        Unit equivalencies allowed during conversion.
+    constraints : `tuple` [`Constraint`, ...], optional
+        Ordered value-level constraints.
+    """
+
+    name: str
+    default: u.Unit
+    equivalencies: list = field(default_factory=list)
+    constraints: tuple[Constraint, ...] = ()
+
+
+class Spec:
+    """Fluent builder producing an immutable :class:`QuantitySpec`.
+
+    Example
+    -------
+    ``Spec("gain", u.electron / u.adu).ranged(0.1, 100).build()``
+    """
+
+    def __init__(self, name: str, default: u.Unit, equivalencies: list | None = None):
+        self._spec = QuantitySpec(name, default, equivalencies or [])
+
+    def _add(self, constraint: Constraint) -> "Spec":
+        self._spec = replace(self._spec, constraints=self._spec.constraints + (constraint,))
+        return self
+
+    def ranged(self, vmin: float, vmax: float) -> "Spec":
+        """Require values within ``[vmin, vmax]``."""
+        return self._add(Range(vmin, vmax))
+
+    def finite(self) -> "Spec":
+        """Require finite values."""
+        return self._add(Finite())
+
+    def with_constraint(self, constraint: Constraint) -> "Spec":
+        """Attach an arbitrary custom constraint."""
+        return self._add(constraint)
+
+    def build(self) -> QuantitySpec:
+        """Return the assembled, immutable specification."""
+        return self._spec
+
 
 def check_quantity(quantity: u.Quantity, spec: QuantitySpec) -> u.Quantity:
     """Check that quantity has valid units and value.
+
+    The unit is converted to the spec's canonical unit, then every
+    value-level constraint is run and all failures are aggregated into a
+    single :class:`QuantityValidationError`.
 
     Parameters
     ----------
@@ -38,8 +160,10 @@ def check_quantity(quantity: u.Quantity, spec: QuantitySpec) -> u.Quantity:
     ------
     TypeError
         Raised if ``quantity`` or ``spec`` are invalid types.
+    QuantityValidationError
+        Raised if ``quantity`` fails one or more value-level constraints.
     ValueError
-        Raised if ``quantity`` fails a validation check.
+        Raised if the unit is not convertible to the canonical unit.
     """
     if not isinstance(spec, QuantitySpec):
         raise TypeError(f"{spec} must be 'metroid.utils.quantities.QuantitySpec'")
@@ -51,16 +175,10 @@ def check_quantity(quantity: u.Quantity, spec: QuantitySpec) -> u.Quantity:
         raise ValueError(f"invalid unit for {spec.name}: {quantity.unit}")
 
     quantity = quantity.to(spec.default, equivalencies=spec.equivalencies)
-    if spec.typical_range is not None:
-        value = quantity.value
-        vmin, vmax = spec.typical_range
-        if np.isscalar(value):
-            if not (vmin <= value <= vmax):
-                raise ValueError(f"{spec.name} value {value} is outside range {vmin}-{vmax}")
 
-        else:
-            if not np.all((value >= vmin) & (value <= vmax)):
-                raise ValueError(f"{spec.name} contains values outside range {vmin}-{vmax}")
+    problems = [msg for c in spec.constraints if (msg := c.check(quantity, spec.name)) is not None]
+    if problems:
+        raise QuantityValidationError(spec.name, problems)
 
     return quantity
 
@@ -99,61 +217,67 @@ def _extract_spec(annotation: Any) -> QuantitySpec | None:
     return None
 
 
-WAVELENGTH = QuantitySpec("wavelength", u.AA)
+# ----------------------------------------------------------------------------
+# Spec catalogue.  Declared with the fluent builder and reads as a table of
+# "what each quantity is".  Range limits are intentionally omitted here and
+# will be reworked per physical quantity on a case-by-case basis.
+# ----------------------------------------------------------------------------
+
+WAVELENGTH = Spec("wavelength", u.AA).build()
 """The wavelength specification."""
 
-GEOMETRY_LENGTH = QuantitySpec("geometry_length", u.m, typical_range=(1e-3, 1e3))
+GEOMETRY_LENGTH = Spec("geometry_length", u.m).build()
 """The geometry length specification."""
 
-ORBITAL_DISTANCE = QuantitySpec("orbital_distance", u.km, typical_range=(1e2, 1e6))
+ORBITAL_DISTANCE = Spec("orbital_distance", u.km).build()
 """The orbital distance specification."""
 
-AREA = QuantitySpec("area", u.m**2, typical_range=(1e-6, 1e6))
+AREA = Spec("area", u.m**2).build()
 """The area specification."""
 
-TIME = QuantitySpec("time", u.s, typical_range=(0.0, 1e5))
+TIME = Spec("time", u.s).build()
 """The time specification."""
 
-VELOCITY = QuantitySpec("velocity", u.m / u.s)
+VELOCITY = Spec("velocity", u.m / u.s).build()
 """The velocity specification."""
 
-ANGLE = QuantitySpec("angle", u.deg)
+ANGLE = Spec("angle", u.deg).build()
 """The angle specification."""
 
-SOLID_ANGLE = QuantitySpec("solid_angle", u.sr, equivalencies=u.dimensionless_angles())
+SOLID_ANGLE = Spec("solid_angle", u.sr, u.dimensionless_angles()).build()
 """The solid angle specification."""
 
-ANGULAR_VELOCITY = QuantitySpec("angular_velocity", u.rad / u.s, equivalencies=u.dimensionless_angles())
+ANGULAR_VELOCITY = Spec("angular_velocity", u.rad / u.s, u.dimensionless_angles()).build()
 """The angular velocity specification."""
 
-ADU = QuantitySpec("adu", u.adu)
+ADU = Spec("adu", u.adu).build()
 """The adu specification."""
 
-GAIN = QuantitySpec("gain", u.electron / u.adu, typical_range=(1e-1, 1e2))
+GAIN = Spec("gain", u.electron / u.adu).build()
 """The gain specification."""
 
-QUANTUM_EFFICIENCY = QuantitySpec("qe", u.electron / u.ph, typical_range=(1e0, 1e2))
+QUANTUM_EFFICIENCY = Spec("qe", u.electron / u.ph).build()
 """The quantum efficiency specification."""
 
-PIXEL_SCALE = QuantitySpec("pixel_scale", u.arcsec / u.pix, typical_range=(1e-2, 1e1))
+PIXEL_SCALE = Spec("pixel_scale", u.arcsec / u.pix).build()
 """The pixel scale specification."""
 
-FRACTION = QuantitySpec("fraction", u.dimensionless_unscaled, typical_range=(0.0, 1.0))
+FRACTION = Spec("fraction", u.dimensionless_unscaled).build()
 """The throughput specification."""
 
-SPECTRAL_FLUX_DENSITY = QuantitySpec("spectral_flux_density", u.erg / (u.s * u.cm**2 * u.AA))
+SPECTRAL_FLUX_DENSITY = Spec("spectral_flux_density", u.erg / (u.s * u.cm**2 * u.AA)).build()
 """The wavelength spectral flux density specification."""
 
-PHOTON_FLUX = QuantitySpec("photon_flux", u.ph / (u.s * u.m**2), equivalencies=[(u.ph, None)])
+PHOTON_FLUX = Spec("photon_flux", u.ph / (u.s * u.m**2), [(u.ph, None)]).build()
 """The spectral photon flux density specification."""
 
-ENERGY_FLUX = QuantitySpec("energy_flux", u.erg / (u.s * u.m**2))
+ENERGY_FLUX = Spec("energy_flux", u.erg / (u.s * u.m**2)).build()
 """The energy flux density (irradiance) specification."""
 
-RADIANCE = QuantitySpec("radiance", u.W / (u.sr * u.m**2))
+RADIANCE = Spec("radiance", u.W / (u.sr * u.m**2)).build()
 """The radiance specification."""
 
-RADIANT_INTENSITY = QuantitySpec("radiant_intensity", u.W / u.sr)
+RADIANT_INTENSITY = Spec("radiant_intensity", u.W / u.sr).build()
 """The radiant intensity specification."""
 
 Wavelength = Annotated[u.Quantity, WAVELENGTH]

--- a/src/metroid/utils/quantities.py
+++ b/src/metroid/utils/quantities.py
@@ -11,8 +11,9 @@ class; the core :func:`check_quantity` validator never changes. The fluent
 :class:`Spec` builder keeps the catalogue declarations terse.
 """
 
+import types
 from dataclasses import dataclass, field, replace
-from typing import Annotated, Any, Protocol, Union, get_args, get_origin, runtime_checkable
+from typing import Annotated, Any, Protocol, TypeAliasType, Union, get_args, get_origin, runtime_checkable
 
 import astropy.units as u
 import numpy as np
@@ -81,6 +82,80 @@ class Finite:
         return None
 
 
+# ----------------------------------------------------------------------------
+# Shape: a separate axis from the physical spec.  Scalar-vs-array is a computer
+# representation, not a physical property, so it lives outside QuantitySpec and
+# is supplied at the annotation site via a generic parameter (e.g. Time[Scalar])
+# and to check_quantity as the ``shape`` argument.
+# ----------------------------------------------------------------------------
+
+
+@runtime_checkable
+class ShapeKind(Protocol):
+    """A check on the array-shape of a quantity (scalar vs. array).
+
+    Mirrors :class:`Constraint` but is kept distinct so that shape is not
+    confused with a physical, value-level constraint.
+    """
+
+    def check(self, quantity: u.Quantity, name: str) -> str | None:
+        """Return an error message, or ``None`` if the shape is allowed."""
+        ...
+
+
+@dataclass(frozen=True)
+class _Scalar:
+    """Require the quantity to be a single scalar value."""
+
+    def check(self, quantity: u.Quantity, name: str) -> str | None:
+        if not quantity.isscalar:
+            return f"must be scalar, got shape {quantity.shape}"
+        return None
+
+
+@dataclass(frozen=True)
+class _Array:
+    """Require the quantity to be array-valued (non-scalar)."""
+
+    def check(self, quantity: u.Quantity, name: str) -> str | None:
+        if quantity.isscalar:
+            return "must be an array, got a scalar"
+        return None
+
+
+@dataclass(frozen=True)
+class _AnyShape:
+    """Impose no shape restriction (scalar or array both allowed)."""
+
+    def check(self, quantity: u.Quantity, name: str) -> str | None:
+        return None
+
+
+# Stateless singletons - one instance of each shape suffices.
+SCALAR: ShapeKind = _Scalar()
+ARRAY: ShapeKind = _Array()
+ANY_SHAPE: ShapeKind = _AnyShape()
+
+
+class Scalar:
+    """Marker type for a scalar quantity. Use as a subscript: ``Time[Scalar]``."""
+
+
+class Array:
+    """Marker type for an array quantity. Use as a subscript: ``Time[Array]``."""
+
+
+class AnyShape:
+    """Marker type imposing no shape restriction (the default for a bare alias)."""
+
+
+_SHAPE_BY_MARKER: dict[Any, ShapeKind] = {
+    Scalar: SCALAR,
+    Array: ARRAY,
+    AnyShape: ANY_SHAPE,
+}
+
+
 @dataclass(frozen=True)
 class QuantitySpec:
     """A physical quantity specification - unit identity plus constraints.
@@ -137,12 +212,12 @@ class Spec:
         return self._spec
 
 
-def check_quantity(quantity: u.Quantity, spec: QuantitySpec) -> u.Quantity:
-    """Check that quantity has valid units and value.
+def check_quantity(quantity: u.Quantity, spec: QuantitySpec, shape: ShapeKind = ANY_SHAPE) -> u.Quantity:
+    """Check that quantity has valid units, value, and shape.
 
     The unit is converted to the spec's canonical unit, then every
-    value-level constraint is run and all failures are aggregated into a
-    single :class:`QuantityValidationError`.
+    value-level constraint and the shape restriction are run and all
+    failures are aggregated into a single :class:`QuantityValidationError`.
 
     Parameters
     ----------
@@ -150,6 +225,9 @@ def check_quantity(quantity: u.Quantity, spec: QuantitySpec) -> u.Quantity:
         The quantity to check.
     spec : `metroid.utils.quantities.QuantitySpec`
         The quantity specification.
+    shape : `metroid.utils.quantities.ShapeKind`, optional
+        The shape restriction (``SCALAR``, ``ARRAY``, or ``ANY_SHAPE``).
+        Defaults to ``ANY_SHAPE`` (scalar or array both allowed).
 
     Returns
     -------
@@ -161,7 +239,7 @@ def check_quantity(quantity: u.Quantity, spec: QuantitySpec) -> u.Quantity:
     TypeError
         Raised if ``quantity`` or ``spec`` are invalid types.
     QuantityValidationError
-        Raised if ``quantity`` fails one or more value-level constraints.
+        Raised if ``quantity`` fails one or more value-level or shape checks.
     ValueError
         Raised if the unit is not convertible to the canonical unit.
     """
@@ -177,14 +255,29 @@ def check_quantity(quantity: u.Quantity, spec: QuantitySpec) -> u.Quantity:
     quantity = quantity.to(spec.default, equivalencies=spec.equivalencies)
 
     problems = [msg for c in spec.constraints if (msg := c.check(quantity, spec.name)) is not None]
+    if (msg := shape.check(quantity, spec.name)) is not None:
+        problems.append(msg)
     if problems:
         raise QuantityValidationError(spec.name, problems)
 
     return quantity
 
 
-def _extract_spec(annotation: Any) -> QuantitySpec | None:
-    """Extract the quantity specification from a type hint.
+def _spec_from_annotated(annotation: Any) -> QuantitySpec | None:
+    """Pull a :class:`QuantitySpec` out of an ``Annotated[...]`` value."""
+    if get_origin(annotation) is Annotated:
+        for meta in get_args(annotation)[1:]:
+            if isinstance(meta, QuantitySpec):
+                return meta
+    return None
+
+
+def _extract_spec(annotation: Any) -> tuple[QuantitySpec | None, ShapeKind]:
+    """Extract the ``(spec, shape)`` pair from a type hint.
+
+    Recurses through generic quantity aliases (``Time``, ``Time[Scalar]``),
+    bare ``Annotated`` hints, and unions (e.g. ``Time[Scalar] | None``). The
+    shape defaults to ``ANY_SHAPE`` when no shape marker is supplied.
 
     Parameters
     ----------
@@ -194,27 +287,41 @@ def _extract_spec(annotation: Any) -> QuantitySpec | None:
     Returns
     -------
     spec : `metroid.utils.quantities.QuantitySpec` or None
-        The extracted quantity specification.
+        The extracted quantity specification, or ``None`` if absent.
+    shape : `metroid.utils.quantities.ShapeKind`
+        The shape restriction; ``ANY_SHAPE`` if unspecified.
     """
     if annotation is None:
-        return None
+        return None, ANY_SHAPE
+
+    # Bare generic alias, e.g. ``Time`` - a TypeAliasType with unbound param.
+    if isinstance(annotation, TypeAliasType):
+        return _spec_from_annotated(annotation.__value__), ANY_SHAPE
 
     origin = get_origin(annotation)
+
+    # Subscripted alias, e.g. ``Time[Scalar]`` - origin is the TypeAliasType,
+    # args carry the supplied shape marker.
+    if isinstance(origin, TypeAliasType):
+        spec = _spec_from_annotated(origin.__value__)
+        args = get_args(annotation)
+        shape = _SHAPE_BY_MARKER.get(args[0], ANY_SHAPE) if args else ANY_SHAPE
+        return spec, shape
+
+    # A directly written ``Annotated`` (not via an alias).
     if origin is Annotated:
-        base, *meta = get_args(annotation)
-        for m in meta:
-            if isinstance(m, QuantitySpec):
-                return m
+        return _spec_from_annotated(annotation), ANY_SHAPE
 
-        return _extract_spec(base)
-
-    if origin is Union:
+    # Optional / Union, e.g. ``Time[Scalar] | None``; first hit wins.
+    # ``X | Y`` (PEP 604) has origin ``types.UnionType``; ``Union[X, Y]`` has
+    # origin ``typing.Union``.
+    if origin is Union or origin is types.UnionType:
         for arg in get_args(annotation):
-            spec = _extract_spec(arg)
-            if spec:
-                return spec
+            spec, shape = _extract_spec(arg)
+            if spec is not None:
+                return spec, shape
 
-    return None
+    return None, ANY_SHAPE
 
 
 # ----------------------------------------------------------------------------
@@ -280,22 +387,27 @@ RADIANCE = Spec("radiance", u.W / (u.sr * u.m**2)).build()
 RADIANT_INTENSITY = Spec("radiant_intensity", u.W / u.sr).build()
 """The radiant intensity specification."""
 
-Wavelength = Annotated[u.Quantity, WAVELENGTH]
-GeometryLength = Annotated[u.Quantity, GEOMETRY_LENGTH]
-OrbitalDistance = Annotated[u.Quantity, ORBITAL_DISTANCE]
-Area = Annotated[u.Quantity, AREA]
-Time = Annotated[u.Quantity, TIME]
-Velocity = Annotated[u.Quantity, VELOCITY]
-Angle = Annotated[u.Quantity, ANGLE]
-SolidAngle = Annotated[u.Quantity, SOLID_ANGLE]
-AngularVelocity = Annotated[u.Quantity, ANGULAR_VELOCITY]
-Adu = Annotated[u.Quantity, ADU]
-Gain = Annotated[u.Quantity, GAIN]
-QuantumEfficiency = Annotated[u.Quantity, QUANTUM_EFFICIENCY]
-PixelScale = Annotated[u.Quantity, PIXEL_SCALE]
-Fraction = Annotated[u.Quantity, FRACTION]
-SpectralFluxDensity = Annotated[u.Quantity, SPECTRAL_FLUX_DENSITY]
-PhotonFlux = Annotated[u.Quantity, PHOTON_FLUX]
-EnergyFlux = Annotated[u.Quantity, ENERGY_FLUX]
-Radiance = Annotated[u.Quantity, RADIANCE]
-RadiantIntensity = Annotated[u.Quantity, RADIANT_INTENSITY]
+# Generic type aliases - one per physical quantity, parameterized by shape.
+# The bare alias (``Time``) means "any shape"; ``Time[Scalar]`` / ``Time[Array]``
+# add a shape restriction.  The wrapped type stays ``u.Quantity``, so static
+# type checkers and editors still treat annotated values as quantities.
+
+type Wavelength[Sh] = Annotated[u.Quantity, WAVELENGTH, Sh]
+type GeometryLength[Sh] = Annotated[u.Quantity, GEOMETRY_LENGTH, Sh]
+type OrbitalDistance[Sh] = Annotated[u.Quantity, ORBITAL_DISTANCE, Sh]
+type Area[Sh] = Annotated[u.Quantity, AREA, Sh]
+type Time[Sh] = Annotated[u.Quantity, TIME, Sh]
+type Velocity[Sh] = Annotated[u.Quantity, VELOCITY, Sh]
+type Angle[Sh] = Annotated[u.Quantity, ANGLE, Sh]
+type SolidAngle[Sh] = Annotated[u.Quantity, SOLID_ANGLE, Sh]
+type AngularVelocity[Sh] = Annotated[u.Quantity, ANGULAR_VELOCITY, Sh]
+type Adu[Sh] = Annotated[u.Quantity, ADU, Sh]
+type Gain[Sh] = Annotated[u.Quantity, GAIN, Sh]
+type QuantumEfficiency[Sh] = Annotated[u.Quantity, QUANTUM_EFFICIENCY, Sh]
+type PixelScale[Sh] = Annotated[u.Quantity, PIXEL_SCALE, Sh]
+type Fraction[Sh] = Annotated[u.Quantity, FRACTION, Sh]
+type SpectralFluxDensity[Sh] = Annotated[u.Quantity, SPECTRAL_FLUX_DENSITY, Sh]
+type PhotonFlux[Sh] = Annotated[u.Quantity, PHOTON_FLUX, Sh]
+type EnergyFlux[Sh] = Annotated[u.Quantity, ENERGY_FLUX, Sh]
+type Radiance[Sh] = Annotated[u.Quantity, RADIANCE, Sh]
+type RadiantIntensity[Sh] = Annotated[u.Quantity, RADIANT_INTENSITY, Sh]

--- a/tests/profiles/test_orbital_objects.py
+++ b/tests/profiles/test_orbital_objects.py
@@ -88,7 +88,7 @@ def test_calculate_pixel_time_invalid(orbital_object):
     instance raises proper exception for invalid cases.
     """
     with pytest.raises(ValueError):
-        orbital_object.calculate_pixel_time(0.0 * (u.arcsec / u.pix))
+        orbital_object.calculate_pixel_time(0.2 * (u.s / u.pix))
 
 
 @pytest.mark.parametrize(

--- a/tests/profiles/test_pupils.py
+++ b/tests/profiles/test_pupils.py
@@ -52,7 +52,7 @@ def test_from_config(config, expected_type):
     "distance,expected_exception",
     [
         ("not a quantity", TypeError),
-        (50.0 * u.km, ValueError),
+        (50.0 * u.s, ValueError),
     ],
 )
 def test_get_profile_invalid(pupil, distance, expected_exception):
@@ -72,7 +72,7 @@ def test_circular_pupil_creation(circular_pupil):
     "radius,expected_error",
     [
         (4.0, TypeError),
-        (0.0 * u.m, ValueError),
+        (4.0 * u.s, ValueError),
     ],
 )
 def test_circular_pupil_creation_invalid(radius, expected_error):
@@ -110,7 +110,6 @@ def test_annular_pupil_creation(annular_pupil):
     [
         (1.0, 4.0 * u.m, TypeError),
         (1.0 * u.m, 4.0, TypeError),
-        (0.0 * u.m, 4.0 * u.m, ValueError),
         (4.0 * u.m, 4.0 * u.m, ValueError),
     ],
 )

--- a/tests/utils/test_decorators.py
+++ b/tests/utils/test_decorators.py
@@ -1,8 +1,9 @@
 from astropy import units as u
 import numpy as np
+import pytest
 
 from metroid.utils.decorators import enforce_units
-from metroid.utils.quantities import GeometryLength, Area
+from metroid.utils.quantities import Array, GeometryLength, Area, QuantityValidationError, Scalar, Time
 
 
 def test_enforce_units():
@@ -36,3 +37,30 @@ def test_enforce_units():
         return None
 
     assert null_return2(5.0 * u.m) is None
+
+
+def test_enforce_units_shape():
+    """Test that generic shape aliases are enforced through the decorator."""
+
+    @enforce_units
+    def needs_scalar(t: Time[Scalar]) -> Time[Scalar]:
+        return t
+
+    assert needs_scalar(5.0 * u.s).unit == u.s
+    with pytest.raises(QuantityValidationError):
+        needs_scalar([1.0, 2.0] * u.s)
+
+    @enforce_units
+    def needs_array(t: Time[Array]) -> Time[Array]:
+        return t
+
+    assert np.all(needs_array([1.0, 2.0] * u.s).value == [1.0, 2.0])
+    with pytest.raises(QuantityValidationError):
+        needs_array(5.0 * u.s)
+
+    @enforce_units
+    def any_shape(t: Time) -> Time:
+        return t
+
+    assert any_shape(5.0 * u.s).unit == u.s
+    assert any_shape([1.0, 2.0] * u.s).unit == u.s

--- a/tests/utils/test_quantities.py
+++ b/tests/utils/test_quantities.py
@@ -1,7 +1,15 @@
 from astropy import units as u
 import pytest
 
-from metroid.utils.quantities import AREA, Area, check_quantity, QuantitySpec, _extract_spec
+from metroid.utils.quantities import (
+    AREA,
+    Area,
+    QuantitySpec,
+    QuantityValidationError,
+    Spec,
+    check_quantity,
+    _extract_spec,
+)
 
 
 def test_quantity_spec_creation():
@@ -9,7 +17,8 @@ def test_quantity_spec_creation():
 
     assert spec.name == "area"
     assert spec.default == (u.m**2)
-    assert spec.typical_range is None
+    assert spec.equivalencies == []
+    assert spec.constraints == ()
 
 
 @pytest.mark.parametrize("q", [0.010 * u.km**2, 10.0 * u.m**2])
@@ -23,7 +32,6 @@ def test_check_quantity_valid(q):
     [
         (10.0, TypeError),
         (10.0 * u.m, ValueError),
-        (0.0 * u.m**2, ValueError),
     ],
 )
 def test_check_quantity_invalid(q, expected_error):
@@ -32,13 +40,35 @@ def test_check_quantity_invalid(q, expected_error):
         check_quantity(q, AREA)
 
 
+def test_check_quantity_converts_to_default_unit():
+    """Test that a valid quantity is converted to the spec's default unit."""
+    assert check_quantity(0.010 * u.km**2, AREA).unit == (u.m**2)
+
+
+def test_range_constraint_aggregates_failures():
+    """Test that value-level constraints raise an aggregated error."""
+    spec = Spec("gain", u.electron / u.adu).ranged(0.1, 100.0).build()
+
+    check_quantity(1.0 * u.electron / u.adu, spec)
+    with pytest.raises(QuantityValidationError):
+        check_quantity(1e3 * u.electron / u.adu, spec)
+
+
+def test_quantity_validation_error_is_value_error():
+    """Test that QuantityValidationError is catchable as ValueError."""
+    spec = Spec("time", u.s).ranged(0.0, 10.0).build()
+
+    with pytest.raises(ValueError):
+        check_quantity(100.0 * u.s, spec)
+
+
 @pytest.mark.parametrize(
     "annotation,expected_spec",
-    {
+    [
         (Area, AREA),
         (None, None),
         (Area | None, AREA),
-    },
+    ],
 )
 def test_extract_spec(annotation, expected_spec):
     """Test that _extract_spec returns correct result for valid cases."""

--- a/tests/utils/test_quantities.py
+++ b/tests/utils/test_quantities.py
@@ -2,11 +2,17 @@ from astropy import units as u
 import pytest
 
 from metroid.utils.quantities import (
+    ANY_SHAPE,
     AREA,
+    ARRAY,
+    SCALAR,
     Area,
+    Array,
     QuantitySpec,
     QuantityValidationError,
+    Scalar,
     Spec,
+    TIME,
     check_quantity,
     _extract_spec,
 )
@@ -62,14 +68,32 @@ def test_quantity_validation_error_is_value_error():
         check_quantity(100.0 * u.s, spec)
 
 
+def test_check_quantity_scalar_shape():
+    """Test that the SCALAR shape rejects arrays and accepts scalars."""
+    check_quantity(5.0 * u.s, TIME, SCALAR)
+    with pytest.raises(QuantityValidationError):
+        check_quantity([1.0, 2.0] * u.s, TIME, SCALAR)
+
+
+def test_check_quantity_array_shape():
+    """Test that the ARRAY shape rejects scalars and accepts arrays."""
+    check_quantity([1.0, 2.0] * u.s, TIME, ARRAY)
+    with pytest.raises(QuantityValidationError):
+        check_quantity(5.0 * u.s, TIME, ARRAY)
+
+
 @pytest.mark.parametrize(
-    "annotation,expected_spec",
+    "annotation,expected_spec,expected_shape",
     [
-        (Area, AREA),
-        (None, None),
-        (Area | None, AREA),
+        (Area, AREA, ANY_SHAPE),
+        (Area[Scalar], AREA, SCALAR),
+        (Area[Array], AREA, ARRAY),
+        (None, None, ANY_SHAPE),
+        (Area[Scalar] | None, AREA, SCALAR),
     ],
 )
-def test_extract_spec(annotation, expected_spec):
-    """Test that _extract_spec returns correct result for valid cases."""
-    assert _extract_spec(annotation) == expected_spec
+def test_extract_spec(annotation, expected_spec, expected_shape):
+    """Test that _extract_spec returns the correct (spec, shape) pair."""
+    spec, shape = _extract_spec(annotation)
+    assert spec == expected_spec
+    assert shape is expected_shape


### PR DESCRIPTION
Implements the scalar-vs-array shape distinction (issue #15) using the approved Formulation A: generic quantity aliases (`Time[Scalar]`).

## Two commits

1. **`refactor(utils)`** — reformulate `QuantitySpec` as a composable constraint algebra (drop `typical_range`; ranges to be reworked per quantity case-by-case).
2. **`feat(utils)`** — add the shape axis: PEP 695 generic aliases, `ShapeKind` protocol with `SCALAR`/`ARRAY`/`ANY_SHAPE` singletons, `check_quantity` shape arg, `(spec, shape)` extraction threaded through `enforce_units`, plus docs + tests.

## Usage

```python
type Time[Sh] = Annotated[u.Quantity, TIME, Sh]
```

Annotate with the bare alias (`Time`, any shape) or subscript it (`Time[Scalar]`, `Time[Array]`). Shape failures aggregate into `QuantityValidationError` alongside value-level constraints.

## Testing

- `pytest tests/profiles/ tests/utils/` → 45 passed.
- `mypy` on the touched modules: no new errors (remaining ones are pre-existing astropy `import-untyped` and `validated_dataclass`).

Profile tests that asserted now-removed range errors are updated to cover wrong-unit and domain (`outer <= inner`) cases instead.

Closes #15

Generated with AI

Co-Authored-By: SLAC AI