### PR TITLE
fix(photometry): isolate filter response and accept int magnitudes

### DIFF
--- a/src/metroid/photometry/CLAUDE.md
+++ b/src/metroid/photometry/CLAUDE.md
@@ -41,3 +41,66 @@ flux, and detector ADU. Wraps `speclite.filters` for the heavy lifting.
 
 - `_ab_constant` and `validate_wavelength_array` are speclite *private/internal*
   API; upgrades to speclite could break `sed.py`.
+- **`_freeze_filter_response` mutates speclite's global filter cache (#19).**
+  `load_filter` returns a *shared, cached* `FilterResponse` whose ndarrays are
+  shared across callers; setting `flags.writeable = False` on them leaks
+  read-only state into every speclite consumer in the process.
+  `from_filter_response(fr)` likewise freezes the caller's object in place. The
+  fix is to copy the wavelength/response arrays before freezing so the freeze
+  only touches arrays this `ThroughputCurve` owns.
+- **`int` AB magnitudes are rejected (#20).** `calculate_energy_flux` /
+  `calculate_adu` advertise `float | int | Sed`, but `_ensure_sed` guards with
+  `isinstance(..., float)`, so an integer magnitude raises `TypeError`. The
+  three public methods also disagree on their hints (`calculate_photon_flux`
+  omits `int`). Note `bool` subclasses `int` — any numeric guard should decide
+  deliberately whether `True`/`False` are valid.
+- **`from_filter_response` hand-mangles `_ThroughputCurve__fr`** via
+  `cls.__new__(cls)`, which trips mypy (`"Self" has no attribute ...`) and is
+  fragile under rename. Routing all three constructors through one private
+  initializer would fix this and is the natural home for the copy-before-freeze
+  fix above.
+- `calculate_ab_magnitude` and `_convolve` bypass `@enforce_units`, unlike the
+  rest of the package's "every public method validates units" pattern.
+- `qe` in `PhotometricParameters` is a scalar `QuantumEfficiency[Scalar]`, so
+  wavelength-dependent detector QE is collapsed to a band average — a known
+  first-approximation limitation, superseded once throughput composition lands
+  (see roadmap).
+
+## Optimization notes (within the current framework)
+
+- **Float/AB path can skip the convolution.** Convolution is linear in
+  `flambda` and the flat reference SED's photon flux *is* `ab_zeropoint`, so
+  `calculate_photon_flux(mag) == ab_zeropoint * 10 ** (-0.4 * mag)`. The float
+  path can return this directly instead of convolving an 8501-point SED.
+- **The reference SED is rebuilt every float call** (`Sed.for_ab_magnitudes()`
+  in `_ensure_sed`, ~1 ms/call of pure waste). Cache it once (module constant /
+  `lru_cache` / cached class attribute).
+- **`_convolve` passes both `sed.flambda` and `units=sed.flambda.unit`** —
+  redundant; pass `.value` with `units=`, or the Quantity alone.
+
+## Roadmap toward LEO-object photometry
+
+The package is currently the **radiometry layer**: SED × bandpass →
+photon/energy flux → ADU. Satellite/debris photometry adds geometry, solar
+illumination, and trailing. Extend via the existing patterns (new `Spec` +
+generic alias in `utils/quantities.py`; `@enforce_units` free functions in
+`conversions.py`; `Constraint` classes), keeping the boundary clean: photometry
+*consumes* scalar geometry (range, solid angle, angular rate) computed by the
+orbital subpackage, and spatial smearing belongs in `profiles`.
+
+- **Range scaling** — `radiant_intensity_to_flux(intensity, range)` closing the
+  inverse-square chain (`RADIANT_INTENSITY` and `ENERGY_FLUX` already exist).
+- **Solar-reflection SEDs** — `Sed.for_solar()` plus a reflectance/albedo hook;
+  satellites reflect sunlight rather than emit it.
+- **Phase angle / standard magnitude** — pluggable phase function and
+  range/phase normalization so predictions match published satellite
+  photometry.
+- **Trailed photometry** — distribute total flux/ADU along the streak using
+  angular rate and exptime to get ADU-per-pixel; trail *geometry* stays in
+  `profiles`.
+- **Atmospheric extinction + composable system throughput** — model QE, mirror
+  reflectivity, and airmass-dependent extinction as `ThroughputCurve`s and
+  compose (`__mul__` / `compose([...])`); this is the principled replacement
+  for scalar `qe`.
+- **Detector realism** (saturation / non-linearity) and **sky-background SNR**
+  for detectability of faint trails.

--- a/src/metroid/photometry/throughput.py
+++ b/src/metroid/photometry/throughput.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Any, Self
 
 import astropy.units as u
@@ -18,7 +19,7 @@ class ThroughputCurve:
     @enforce_units
     def __init__(self, wavelength: Wavelength[Array], throughput: Fraction[Array], meta: dict[str, Any]):
         fr = FilterResponse(wavelength.value, throughput.value, meta)
-        self.__fr = self._freeze_filter_response(fr)
+        self.__fr = self._adopt_filter_response(fr)
 
     @classmethod
     def from_filter_response(cls, fr: FilterResponse) -> Self:
@@ -43,7 +44,7 @@ class ThroughputCurve:
             raise TypeError("fr must be 'FilterResponse'")
 
         throughput_curve = cls.__new__(cls)
-        throughput_curve._ThroughputCurve__fr = cls._freeze_filter_response(fr)
+        throughput_curve.__fr = cls._adopt_filter_response(fr)
         return throughput_curve
 
     @classmethod
@@ -102,12 +103,12 @@ class ThroughputCurve:
         return self.__fr.ab_zeropoint
 
     @enforce_units
-    def calculate_photon_flux(self, brightness_spec: float | Sed) -> PhotonFlux[Scalar]:
+    def calculate_photon_flux(self, brightness_spec: float | int | Sed) -> PhotonFlux[Scalar]:
         """Calculate a photon flux density.
 
         Parameters
         ----------
-        brightness_spec : `float` or `metroid.photometry.Sed`
+        brightness_spec : `float`, `int`, or `metroid.photometry.Sed`
             The brightness specification. Can be either an AB magnitude or the
             SED of an observed object.
 
@@ -120,7 +121,7 @@ class ThroughputCurve:
         Raises
         ------
         TypeError
-            Raised if ``brightness_spec`` is unsupported type:
+            Raised if ``brightness_spec`` is an unsupported type.
         """
         sed = self._ensure_sed(brightness_spec)
         return self._convolve(sed, photon_weighted=True)
@@ -215,7 +216,8 @@ class ThroughputCurve:
         if isinstance(brightness_spec, Sed):
             return brightness_spec
 
-        elif isinstance(brightness_spec, float):
+        # ``bool`` subclasses ``int`` but is not a valid magnitude.
+        elif isinstance(brightness_spec, (int, float)) and not isinstance(brightness_spec, bool):
             sed = Sed.for_ab_magnitudes()
 
             scale = 10 ** (-0.4 * brightness_spec)
@@ -249,7 +251,27 @@ class ThroughputCurve:
         return result
 
     @staticmethod
-    def _freeze_filter_response(fr: FilterResponse) -> FilterResponse:
+    def _adopt_filter_response(fr: FilterResponse) -> FilterResponse:
+        """Take private, immutable ownership of a filter response.
+
+        ``speclite.filters.load_filter`` returns a *shared, cached*
+        ``FilterResponse`` whose underlying arrays are reused across callers,
+        so freezing them in place would leak read-only state into speclite's
+        global cache. A ``deepcopy`` yields an independent object with
+        independent arrays (and bypasses ``FilterResponse.__init__``, so it is
+        not re-registered into the cache); freezing that copy is safe.
+
+        Parameters
+        ----------
+        fr : `speclite.filters.FilterResponse`
+            The filter response to take ownership of.
+
+        Returns
+        -------
+        fr : `speclite.filters.FilterResponse`
+            A private, frozen copy of the filter response.
+        """
+        fr = copy.deepcopy(fr)
         fr._wavelength.flags.writeable = False
         fr._response.flags.writeable = False
         return fr

--- a/tests/photometry/test_throughput.py
+++ b/tests/photometry/test_throughput.py
@@ -60,3 +60,28 @@ def test_calculate_ab_magnitude(bandpass):
     sed = Sed.for_ab_magnitudes()
 
     assert np.isclose(bandpass.calculate_ab_magnitude(sed), 0.0)
+
+
+def test_int_magnitude_supported(bandpass):
+    """Regression for #20: int AB magnitudes must be accepted and agree with
+    the equivalent float.
+    """
+    assert u.isclose(bandpass.calculate_photon_flux(20), bandpass.calculate_photon_flux(20.0))
+    assert u.isclose(bandpass.calculate_energy_flux(20), bandpass.calculate_energy_flux(20.0))
+
+
+def test_bool_magnitude_rejected(bandpass):
+    """``bool`` subclasses ``int`` but is not a valid magnitude."""
+    with pytest.raises(TypeError):
+        bandpass.calculate_photon_flux(True)
+
+
+def test_wrap_does_not_freeze_speclite_cache():
+    """Regression for #19: wrapping a filter must not freeze speclite's shared
+    cached arrays.
+    """
+    ThroughputCurve.load_filter("lsst2023-g")
+    fr = load_filter("lsst2023-g")
+
+    assert fr.wavelength.flags.writeable
+    assert fr.response.flags.writeable


### PR DESCRIPTION
## Summary

Fixes two confirmed photometry bugs surfaced during the `metroid.photometry` review, plus a constructor consolidation that resolves a mypy error.

Fixes #19
Fixes #20

## #19 — speclite cache mutation

`_freeze_filter_response` set `flags.writeable = False` directly on the **shared, cached** ndarrays returned by `speclite.load_filter`, leaking read-only state into speclite's global filter cache (every consumer in the process saw frozen arrays).

Root cause is deeper than freezing-in-place: `FilterResponse.__init__` *self-registers into `_filter_cache` by meta name*, so naively rebuilding from copied arrays just clobbers the cache with our object. The fix is `_adopt_filter_response`, which `copy.deepcopy`s the `FilterResponse` — yielding independent arrays **and** bypassing `__init__` (so no re-registration) — then freezes the private copy. All three constructors (`__init__`, `from_filter_response`, `load_filter`) now route through it.

This also lets `from_filter_response` drop the hard-coded `_ThroughputCurve__fr` name-mangling that tripped mypy (`"Self" has no attribute ...`).

## #20 — int AB magnitudes rejected

`_ensure_sed` guarded with `isinstance(..., float)`, so an integer magnitude raised `TypeError` despite `int` being advertised in the signatures/docstrings. Now accepts `(int, float)` while explicitly rejecting `bool` (a subclass of `int`), and `calculate_photon_flux`'s signature is unified with the other entry points.

## Tests

Added regression tests:
- `test_int_magnitude_supported` — int agrees with float for photon/energy flux.
- `test_bool_magnitude_rejected` — `bool` raises `TypeError`.
- `test_wrap_does_not_freeze_speclite_cache` — wrapping a filter leaves speclite's shared arrays writeable.

Full suite: 69 passed. `black` clean; `mypy` shows only the pre-existing astropy/speclite import-untyped notes.

## Out of scope

Lint/docstring sweep (incl. the `photo_params.py` F401) is tracked separately in #21.