### PR TITLE
docs: recreate technical documentation per guidelines

### DIFF
--- a/src/metroid/CLAUDE.md
+++ b/src/metroid/CLAUDE.md
@@ -1,53 +1,17 @@
-# `metroid` — top-level package
+# metroid/
 
-Core entry points that compose the rest of the library. See the root
-`CLAUDE.md` for project-wide development rules; this file is context for
-working inside `src/metroid/` and its subpackages.
+## Files
 
-## Mental model
+| File | What | When to read |
+| ---- | ---- | ------------ |
+| `observatory.py` | `Observatory` class composing a `Camera`, `Pupil`, and `EarthLocation`; `get_photo_params` method | Implementing or modifying top-level observatory construction; debugging `PhotometricParameters` creation |
+| `camera.py` | `Camera` class holding named `ThroughputCurve` bandpasses, gain, pixel scale, and quantum efficiency | Implementing or modifying camera construction; debugging bandpass lookup or iteration |
+| `__init__.py` | Empty package init | Checking what the top-level package exports |
 
-`metroid` simulates streaks/trails left by orbiting objects (satellites,
-debris) in astronomical images. The pipeline conceptually is:
+## Subdirectories
 
-```
-OrbitalObject (geometry, velocity, surface-brightness profile)
-        +  Pupil (telescope aperture -> defocus profile)
-        +  PSF (galsim)                       --> tracked galsim profile
-ThroughputCurve + Sed + PhotometricParameters --> flux / ADU scaling
-```
-
-The top-level module wires the optics together:
-
-- **`Observatory`** (`observatory.py`) — composes a `Camera`, a `Pupil`, and an
-  `astropy.coordinates.EarthLocation`. Validates each argument by `isinstance`
-  in `__init__` (raises `ValueError` on mismatch). `get_photo_params(exptime)`
-  builds a `PhotometricParameters` from the camera gain/qe and pupil area.
-- **`Camera`** (`camera.py`) — an immutable container of named bandpasses
-  (`dict[str, ThroughputCurve]`, wrapped in a `MappingProxyType`) plus `gain`,
-  `pixel_scale`, and `qe`. Supports `camera[name]`, iteration, and `len()`.
-  Unknown keys raise `ValueError` (not `KeyError`).
-
-## Conventions used everywhere in `src/`
-
-- **Unit enforcement is the central pattern.** Almost every public method and
-  property is decorated with `@enforce_units` (from `utils/decorators.py`),
-  which reads the generic quantity aliases in `utils/quantities.py`
-  (e.g. `Gain`, `Time`, `Area`; subscript for shape, e.g. `Time[Scalar]`) and
-  validates the unit/equivalency/constraints *and* shape of inputs *and* the
-  return value. To add a new physical quantity, add a `Spec(...)` constant plus
-  a `type NewQuantity[Sh] = Annotated[u.Quantity, NEW_QUANTITY, Sh]` alias in
-  `utils/quantities.py` and annotate with it — do not hand-roll unit checks.
-- **Immutability is intentional.** Containers expose read-only properties and
-  use `MappingProxyType` / frozen dataclasses / frozen numpy arrays. Recent
-  history ("more protected immutability") shows this is a deliberate design
-  value — preserve it.
-- Type hints are required on all code; line length 110 (code) / 79
-  (docstrings); numpydoc style.
-
-## Known issues / gotchas (top-level)
-
-- `Observatory.__init__` validates by `isinstance` and raises `ValueError` for
-  a bad type, whereas most of the codebase raises `TypeError` for type
-  mismatches — inconsistent but currently relied on by tests.
-- `Camera.__getitem__` translates a missing key into `ValueError`, so callers
-  catch `ValueError`, not `KeyError`.
+| Directory | What | When to read |
+| --------- | ---- | ------------ |
+| `photometry/` | Radiometry layer: `ThroughputCurve`, `Sed`, `PhotometricParameters`, flux/ADU conversion functions | Implementing photometric calculations; debugging flux or ADU outputs |
+| `profiles/` | Telescope pupil geometry and orbital object surface-brightness profiles | Implementing or modifying pupil shapes, orbital object geometry, or tracked galsim profiles |
+| `utils/` | Unit enforcement machinery: quantity specs, `@enforce_units` decorator, config validation | Adding a new physical quantity; debugging unit validation errors; modifying enforcement behavior |

--- a/src/metroid/README.md
+++ b/src/metroid/README.md
@@ -1,0 +1,62 @@
+# metroid
+
+## Overview
+
+`metroid` simulates streaks and trails in astronomical images caused by
+orbital objects such as satellites and space debris. It models the
+geometry of the object and telescope, computes surface-brightness
+profiles via galsim, and scales them to detector ADU through a
+radiometry layer.
+
+## Architecture
+
+The simulation pipeline has two parallel threads that combine at the
+end:
+
+```
+OrbitalObject (geometry, velocity, surface-brightness profile)
+        +  Pupil (telescope aperture -> defocus profile)
+        +  PSF (galsim)                       --> tracked galsim profile
+ThroughputCurve + Sed + PhotometricParameters --> flux / ADU scaling
+```
+
+`Observatory` (`observatory.py`) composes a `Camera`, a `Pupil`, and
+an `astropy.coordinates.EarthLocation`. Its `get_photo_params(exptime)`
+method builds a `PhotometricParameters` instance from camera gain and
+qe combined with pupil area — the single entry point for photometric
+scaling.
+
+`Camera` (`camera.py`) is an immutable container of named bandpasses
+(`dict[str, ThroughputCurve]` wrapped in `MappingProxyType`) plus
+gain, `pixel_scale`, and qe. It supports item access by filter name
+(`camera[name]`), iteration over filter names, and `len()`.
+
+Subpackages:
+
+- `profiles/` — pupil geometry and orbital object surface-brightness
+  profiles
+- `photometry/` — flux and ADU calculation
+- `utils/` — unit enforcement machinery shared across the package
+
+## Design Decisions
+
+**Unit enforcement is the central pattern.** Almost every public
+method and property is decorated with `@enforce_units` (from
+`utils/decorators.py`), reading quantity type aliases from
+`utils/quantities.py`. To add a new physical quantity, define a
+`QuantitySpec` constant and a matching generic alias in
+`utils/quantities.py` rather than writing bespoke unit checks inline.
+
+**Immutability is intentional.** Read-only properties, `MappingProxyType`
+for the bandpass dict, frozen dataclasses, and frozen numpy arrays are
+all deliberate choices. Preserve this pattern when adding new classes.
+
+## Invariants
+
+`Observatory.__init__` validates its arguments with `isinstance` and
+raises `ValueError` (not `TypeError`) on a bad type — this is
+inconsistent with the rest of the codebase and is currently relied on
+by tests (tracked in issue #23).
+
+`Camera.__getitem__` raises `ValueError`, not `KeyError`, for an
+unknown bandpass name (tracked in issue #24).

--- a/src/metroid/camera.py
+++ b/src/metroid/camera.py
@@ -10,6 +10,7 @@ from metroid.utils.quantities import Gain, PixelScale, QuantumEfficiency
 
 
 class Camera:
+    """An imaging camera with named filter bandpasses."""
 
     @enforce_units
     def __init__(

--- a/src/metroid/photometry/CLAUDE.md
+++ b/src/metroid/photometry/CLAUDE.md
@@ -1,106 +1,11 @@
-# `metroid.photometry`
+# photometry/
 
-Radiometry layer: turning spectra and bandpasses into photon flux, energy
-flux, and detector ADU. Wraps `speclite.filters` for the heavy lifting.
+## Files
 
-## Modules
-
-- **`throughput.py` — `ThroughputCurve`.** Fractional transmission vs.
-  wavelength, backed by a `speclite.filters.FilterResponse`. Constructors:
-  `__init__(wavelength, throughput, meta)`, `from_filter_response(fr)`,
-  `load_filter(name)` (loads a speclite-registered filter, e.g.
-  `"lsst2023-g"`). Key methods:
-  - `calculate_photon_flux` / `calculate_energy_flux` — convolve the curve
-    with an SED (photon- or energy-weighted).
-  - `calculate_adu(brightness_spec, photo_params)` — photon flux scaled to ADU.
-  - `calculate_ab_magnitude(sed)`.
-  - `brightness_spec` may be a `Sed` *or* a `float` AB magnitude;
-    `_ensure_sed` converts a float by scaling a flat-AB reference SED by
-    `10 ** (-0.4 * mag)`.
-  - Immutability: the underlying `FilterResponse` wavelength/response arrays are
-    frozen (`_freeze_filter_response` sets `flags.writeable = False`).
-- **`sed.py` — `Sed`.** A spectral energy distribution (`wavelength`,
-  `flambda`). `for_ab_magnitudes()` builds a flat reference SED
-  (`flambda = _ab_constant / wavelength**2`) used as the magnitude reference.
-  Wavelengths are validated/normalized to Angstrom via
-  `speclite.filters.validate_wavelength_array`.
-- **`photo_params.py` — `PhotometricParameters`.** A frozen, unit-validated
-  dataclass (`@validated_dataclass(frozen=True)`) holding `exptime`, `gain`,
-  `area`, `qe`. This is the one dataclass-style validated type in the codebase.
-- **`conversions.py`** — free functions: `energy_flux_to_radiance(flux,
-  solid_angle)` and `photon_flux_to_adu(photon_flux, photo_params)`.
-
-## Dependencies
-
-- External: `speclite` (`FilterResponse`, `load_filter`, `_ab_constant`,
-  `validate_wavelength_array`), `astropy.units`.
-- Internal: `metroid.utils.decorators.enforce_units` / `validated_dataclass`
-  and the quantity aliases in `metroid.utils.quantities`.
-
-## Known issues / gotchas
-
-- `_ab_constant` and `validate_wavelength_array` are speclite *private/internal*
-  API; upgrades to speclite could break `sed.py`.
-- **`_freeze_filter_response` mutates speclite's global filter cache (#19).**
-  `load_filter` returns a *shared, cached* `FilterResponse` whose ndarrays are
-  shared across callers; setting `flags.writeable = False` on them leaks
-  read-only state into every speclite consumer in the process.
-  `from_filter_response(fr)` likewise freezes the caller's object in place. The
-  fix is to copy the wavelength/response arrays before freezing so the freeze
-  only touches arrays this `ThroughputCurve` owns.
-- **`int` AB magnitudes are rejected (#20).** `calculate_energy_flux` /
-  `calculate_adu` advertise `float | int | Sed`, but `_ensure_sed` guards with
-  `isinstance(..., float)`, so an integer magnitude raises `TypeError`. The
-  three public methods also disagree on their hints (`calculate_photon_flux`
-  omits `int`). Note `bool` subclasses `int` — any numeric guard should decide
-  deliberately whether `True`/`False` are valid.
-- **`from_filter_response` hand-mangles `_ThroughputCurve__fr`** via
-  `cls.__new__(cls)`, which trips mypy (`"Self" has no attribute ...`) and is
-  fragile under rename. Routing all three constructors through one private
-  initializer would fix this and is the natural home for the copy-before-freeze
-  fix above.
-- `calculate_ab_magnitude` and `_convolve` bypass `@enforce_units`, unlike the
-  rest of the package's "every public method validates units" pattern.
-- `qe` in `PhotometricParameters` is a scalar `QuantumEfficiency[Scalar]`, so
-  wavelength-dependent detector QE is collapsed to a band average — a known
-  first-approximation limitation, superseded once throughput composition lands
-  (see roadmap).
-
-## Optimization notes (within the current framework)
-
-- **Float/AB path can skip the convolution.** Convolution is linear in
-  `flambda` and the flat reference SED's photon flux *is* `ab_zeropoint`, so
-  `calculate_photon_flux(mag) == ab_zeropoint * 10 ** (-0.4 * mag)`. The float
-  path can return this directly instead of convolving an 8501-point SED.
-- **The reference SED is rebuilt every float call** (`Sed.for_ab_magnitudes()`
-  in `_ensure_sed`, ~1 ms/call of pure waste). Cache it once (module constant /
-  `lru_cache` / cached class attribute).
-- **`_convolve` passes both `sed.flambda` and `units=sed.flambda.unit`** —
-  redundant; pass `.value` with `units=`, or the Quantity alone.
-
-## Roadmap toward LEO-object photometry
-
-The package is currently the **radiometry layer**: SED × bandpass →
-photon/energy flux → ADU. Satellite/debris photometry adds geometry, solar
-illumination, and trailing. Extend via the existing patterns (new `Spec` +
-generic alias in `utils/quantities.py`; `@enforce_units` free functions in
-`conversions.py`; `Constraint` classes), keeping the boundary clean: photometry
-*consumes* scalar geometry (range, solid angle, angular rate) computed by the
-orbital subpackage, and spatial smearing belongs in `profiles`.
-
-- **Range scaling** — `radiant_intensity_to_flux(intensity, range)` closing the
-  inverse-square chain (`RADIANT_INTENSITY` and `ENERGY_FLUX` already exist).
-- **Solar-reflection SEDs** — `Sed.for_solar()` plus a reflectance/albedo hook;
-  satellites reflect sunlight rather than emit it.
-- **Phase angle / standard magnitude** — pluggable phase function and
-  range/phase normalization so predictions match published satellite
-  photometry.
-- **Trailed photometry** — distribute total flux/ADU along the streak using
-  angular rate and exptime to get ADU-per-pixel; trail *geometry* stays in
-  `profiles`.
-- **Atmospheric extinction + composable system throughput** — model QE, mirror
-  reflectivity, and airmass-dependent extinction as `ThroughputCurve`s and
-  compose (`__mul__` / `compose([...])`); this is the principled replacement
-  for scalar `qe`.
-- **Detector realism** (saturation / non-linearity) and **sky-background SNR**
-  for detectability of faint trails.
+| File | What | When to read |
+| ---- | ---- | ------------ |
+| `throughput.py` | `ThroughputCurve` class wrapping a `speclite` `FilterResponse`; methods to calculate photon flux, energy flux, ADU, and AB magnitude from an SED or AB magnitude float | Implementing bandpass convolution; debugging photon/energy flux or ADU calculations; adding filter loading |
+| `sed.py` | `Sed` class holding wavelength and spectral flux density arrays; `for_ab_magnitudes` factory for a flat AB reference SED | Implementing or modifying spectral energy distributions; debugging AB magnitude conversions |
+| `photo_params.py` | `PhotometricParameters` frozen, unit-validated dataclass holding exposure time, gain, area, and quantum efficiency | Implementing observations requiring photometric scaling; debugging parameter construction |
+| `conversions.py` | Free functions `energy_flux_to_radiance` and `photon_flux_to_adu` | Implementing flux unit conversions; adding new photometric conversion functions |
+| `__init__.py` | Public exports: `ThroughputCurve`, `Sed`, `PhotometricParameters`, `energy_flux_to_radiance`, `photon_flux_to_adu` | Checking what `metroid.photometry` exposes |

--- a/src/metroid/photometry/README.md
+++ b/src/metroid/photometry/README.md
@@ -1,0 +1,57 @@
+# photometry
+
+## Overview
+
+The radiometry layer turns spectra and bandpasses into photon flux,
+energy flux, and detector ADU. It wraps `speclite.filters` for filter
+response handling and exposes a small set of classes and free functions
+as the public interface.
+
+## Architecture
+
+`ThroughputCurve` represents fractional transmission as a function of
+wavelength, backed by a private `speclite.filters.FilterResponse`.
+Three constructors are provided: `__init__` (wavelength and throughput
+arrays), `from_filter_response` (from an existing `FilterResponse`),
+and `load_filter` (by filter name). Methods on the class
+(`calculate_photon_flux`, `calculate_energy_flux`, `calculate_adu`,
+`calculate_ab_magnitude`) accept a `brightness_spec` that is either a
+`Sed` instance or a numeric AB magnitude. When a numeric magnitude is
+supplied, `_ensure_sed` constructs a flat-AB reference `Sed` and scales
+its flux by `10**(-0.4 * mag)` before convolving.
+
+`Sed` holds a wavelength array and a spectral flux density array
+(`flambda`). The `for_ab_magnitudes()` classmethod builds the flat-AB
+reference SED used internally by `ThroughputCurve._ensure_sed`.
+
+`PhotometricParameters` is a frozen, unit-validated dataclass (using
+`validated_dataclass` from `utils/decorators.py`) holding `exptime`,
+`gain`, `area`, and `qe`. It is the one dataclass-style validated type
+in the package.
+
+`conversions.py` provides free functions `energy_flux_to_radiance` and
+`photon_flux_to_adu`, which are also the computation kernels called by
+`ThroughputCurve.calculate_adu`.
+
+## Design Decisions
+
+**Filter-response ownership.** `speclite.filters.load_filter` returns
+a shared, cached `FilterResponse` whose underlying arrays are reused
+across callers. `_adopt_filter_response` calls `copy.deepcopy` on the
+`FilterResponse` to obtain independent arrays and to bypass
+`FilterResponse.__init__`, preventing re-registration into the speclite
+global cache. It then freezes the private copy by setting
+`flags.writeable = False`. All three `ThroughputCurve` constructors
+route through this method, so a `ThroughputCurve` only ever freezes
+arrays it exclusively owns.
+
+**Scalar QE.** The `qe` field in `PhotometricParameters` is a scalar
+quantity, meaning wavelength-dependent detector quantum efficiency is
+collapsed to a band average. This is a deliberate first-approximation
+limitation.
+
+## Invariants
+
+`sed.py` depends on speclite private/internal API (`_ab_constant`,
+`validate_wavelength_array`). A speclite upgrade could silently break
+this module (tracked in issue #26).

--- a/src/metroid/photometry/sed.py
+++ b/src/metroid/photometry/sed.py
@@ -26,16 +26,16 @@ class Sed:
         Parameters
         ----------
         wl_min : `float`
-            The minimum wavelength.
+            The minimum wavelength, in nanometers.
         wl_max : `float`
-            Maximum wavelength value.
+            The maximum wavelength, in nanometers.
         wl_step : `float`
-            The wavelength increment value.
+            The wavelength step size, in nanometers.
 
         Returns
         -------
         sed : `Sed`
-            An instance of `Sed` initialized for AB magnitude calcultions.
+            An instance of `Sed` initialized for AB magnitude calculations.
         """
         wavelength = np.arange(wl_min, wl_max + wl_step, wl_step) * u.nm
         flambda = (_ab_constant / wavelength**2).to(u.erg / (u.s * u.cm**2 * u.AA))

--- a/src/metroid/photometry/throughput.py
+++ b/src/metroid/photometry/throughput.py
@@ -145,7 +145,7 @@ class ThroughputCurve:
         Raises
         ------
         TypeError
-            Raised if ``brightness_spec`` is an unsupported type:
+            Raised if ``brightness_spec`` is an unsupported type.
         """
         sed = self._ensure_sed(brightness_spec)
         return self._convolve(sed, photon_weighted=False)

--- a/src/metroid/profiles/CLAUDE.md
+++ b/src/metroid/profiles/CLAUDE.md
@@ -1,66 +1,9 @@
-# `metroid.profiles`
+# profiles/
 
-Geometry and surface-brightness profiles for telescope pupils and orbiting
-objects. This is where the orbital mechanics and the `galsim` profile
-construction live.
+## Files
 
-## Modules
-
-### `pupils.py` — telescope apertures
-
-- **`Pupil`** (ABC). Holds a class-level `_registry` of subclasses keyed by a
-  `pupil_type` string (registered via `__init_subclass__(pupil_type=...)`).
-  `Pupil.from_config(config)` reads `config["type"]`, looks up the subclass, and
-  delegates to that subclass's `_from_config`. Abstract members: `area`,
-  `get_profile(distance)`, `_from_config`.
-- **`CircularPupil`** (`pupil_type="circular"`) — single `radius`; profile is a
-  `galsim.TopHat`.
-- **`AnnularPupil`** (`pupil_type="annular"`) — `inner_radius` / `outer_radius`
-  (validates `outer > inner`); profile is a difference of two `TopHat`s
-  (`galsim.Sum`), with the inner disk flux-weighted by `(r_i / r_o)**2` to
-  produce a flat annulus.
-- `get_profile(distance)` converts a physical aperture size to an angular size
-  via `(radius / distance).to_value(u.arcsec, equivalencies=dimensionless_angles())`.
-
-### `orbital_objects.py` — orbiting objects
-
-- **`OrbitalObject`** (ABC). State: `height`, `zenith_angle`, `rotation_angle`,
-  `nadir_pointing` (all mutable via unit-enforced setters; `nadir_pointing` is a
-  plain bool). Derived read-only geometry:
-  - `nadir_angle` — `arcsin(R_earth sin(zenith) / (R_earth + height))`.
-  - `distance` — telescope-to-object range (special-cased to `height` when
-    `zenith_angle ≈ 0`).
-  - `orbital_velocity` — `sqrt(G M_earth / (R_earth + height))` (assumes a
-    circular orbit).
-  - `orbital_angular_velocity`, `perpendicular_velocity`,
-    `perpendicular_angular_velocity`, `solid_angle`.
-  - `calculate_pixel_time(pixel_scale)` — time to cross one pixel.
-  - `get_tracked_profile(psf, pupil)` — convolves the object profile with the
-    pupil defocus profile and the PSF (`galsim.Convolve`).
-  - `_project(profile)` — applies foreshortening (cos(nadir_angle)) and rotation
-    when `nadir_pointing` is set.
-- **`CircularOrbitalObject`** — `radius`; profile `galsim.TopHat`.
-- **`RectangularOrbitalObject`** — `width` / `length`; profile `galsim.Box`.
-
-## Dependencies
-
-- External: `galsim`, `astropy.units`, `astropy.constants` (`G`, `R_earth`,
-  `M_earth`).
-- Internal: `metroid.utils` (`enforce_units`, quantity aliases, `get_field_value`).
-
-## Known issues / gotchas
-
-- **`__init__.py` `__all__` typo.** `__all__` listed `"RectangularOrbit"`, which
-  is not a real symbol (the class is `RectangularOrbitalObject`), so
-  `from metroid.profiles import *` raised. Fixed on branch
-  `documentation/dev-context-and-cleanup`; verify before relying on star
-  imports.
-- **`RectangularOrbitalObject.__init__` is not decorated with `@enforce_units`**,
-  unlike `CircularOrbitalObject.__init__`. Its `width`/`length` are only
-  validated lazily when the property getters run, so a bad-unit value can be
-  stored and only fail later. Consider adding the decorator for consistency.
-- `orbital_velocity` assumes a circular orbit at `height`; there is no
-  eccentricity / inclination model yet.
-- The orbital-mechanics derivations (nadir angle, distance, perpendicular
-  velocity) are mirrored in `tests/profiles/test_orbital_objects.py` — that test
-  is the spec for the geometry; keep them in sync.
+| File | What | When to read |
+| ---- | ---- | ------------ |
+| `pupils.py` | `Pupil` ABC with `from_config` registry dispatch; `CircularPupil` and `AnnularPupil` concrete classes with `area` and `get_profile` returning galsim aperture profiles | Implementing or modifying telescope aperture shapes; debugging pupil construction from config; adding a new pupil type |
+| `orbital_objects.py` | `OrbitalObject` ABC with orbital mechanics properties (distance, velocity, angular velocity, solid angle) and `get_tracked_profile`; `CircularOrbitalObject` and `RectangularOrbitalObject` concrete classes with galsim surface-brightness profiles | Implementing or modifying orbital object geometry; debugging profile construction or pixel traversal time; adding a new orbital object shape |
+| `__init__.py` | Public exports: `Pupil`, `CircularPupil`, `AnnularPupil`, `OrbitalObject`, `CircularOrbitalObject`, `RectangularOrbitalObject` | Checking what `metroid.profiles` exposes |

--- a/src/metroid/profiles/README.md
+++ b/src/metroid/profiles/README.md
@@ -1,0 +1,56 @@
+# profiles
+
+## Overview
+
+Geometry and surface-brightness profiles for telescope pupils and
+orbiting objects. This is where orbital mechanics and galsim profile
+construction live.
+
+## Architecture
+
+**Pupil hierarchy.** `Pupil` is an ABC with a class-level `_registry`
+dict. Concrete subclasses register themselves by passing
+`pupil_type="<name>"` to their class statement, which triggers
+`__init_subclass__`. `Pupil.from_config(config)` reads `config["type"]`,
+looks up the subclass in `_registry`, and delegates construction to
+its `_from_config` classmethod. `CircularPupil` produces a
+`galsim.TopHat` profile; `AnnularPupil` produces the difference of
+two `TopHat` objects (the inner disk's flux is weighted by
+`(r_i / r_o)**2` to represent the blocked area). Both convert
+physical aperture radius to an angular size using
+`dimensionless_angles()` equivalencies at the observed distance.
+
+**OrbitalObject hierarchy.** `OrbitalObject` is an ABC with mutable,
+unit-enforced state (`height`, `zenith_angle`, `rotation_angle`) and
+a bool flag `nadir_pointing`. Derived read-only geometry properties
+(`nadir_angle`, `distance`, `orbital_velocity`,
+`orbital_angular_velocity`, `perpendicular_velocity`,
+`perpendicular_angular_velocity`, `solid_angle`) are computed from
+this state. `calculate_pixel_time(pixel_scale)` converts
+`perpendicular_angular_velocity` to pixel traversal time.
+`get_tracked_profile(psf, pupil)` convolves the object's own profile
+with the pupil defocus profile and a galsim PSF. `_project` applies
+foreshortening (scaled by `cos(nadir_angle)`) and rotation when
+`nadir_pointing` is `True`. `CircularOrbitalObject` produces a
+`galsim.TopHat` profile; `RectangularOrbitalObject` produces a
+`galsim.Box`.
+
+## Design Decisions
+
+`orbital_velocity` assumes a circular orbit at `height`:
+`sqrt(G * M_earth / (R_earth + height))`. Orbital eccentricity and
+inclination are not modelled.
+
+## Invariants
+
+The orbital-mechanics derivations (nadir angle, distance,
+perpendicular velocity) are mirrored in
+`tests/profiles/test_orbital_objects.py`. That test file is the
+authoritative spec for the geometry; keep it in sync with any changes
+to the derivations in `orbital_objects.py`.
+
+`RectangularOrbitalObject.__init__` is not decorated with
+`@enforce_units`, unlike `CircularOrbitalObject.__init__`. This means
+`width` and `length` are only validated lazily when their property
+getters run — a bad-unit value can be stored and raise later
+(tracked in issue #13).

--- a/src/metroid/profiles/orbital_objects.py
+++ b/src/metroid/profiles/orbital_objects.py
@@ -66,7 +66,8 @@ class OrbitalObject(ABC):
     @enforce_units
     def rotation_angle(self) -> Angle:
         """The rotation angle of the object from the horizon, in degrees
-        (`astropy.units.Quantity`)."""
+        (`astropy.units.Quantity`).
+        """
         return self._rotation_angle
 
     @rotation_angle.setter

--- a/src/metroid/profiles/pupils.py
+++ b/src/metroid/profiles/pupils.py
@@ -45,7 +45,7 @@ class Pupil(ABC):
         Returns
         -------
         pupil : `Pupil`
-            An instance of a subclass of `Pupil` intialized with the
+            An instance of a subclass of `Pupil` initialized with the
             configuration values.
 
         Raises
@@ -248,7 +248,7 @@ class AnnularPupil(Pupil, pupil_type="annular"):
 
     @enforce_units
     def get_profile(self, distance: OrbitalDistance) -> galsim.Sum:
-        """Get the surface brightness profile of the pupil
+        """Get the surface brightness profile of the pupil.
 
         Parameters
         ----------

--- a/src/metroid/utils/CLAUDE.md
+++ b/src/metroid/utils/CLAUDE.md
@@ -1,100 +1,10 @@
-# `metroid.utils`
+# utils/
 
-The unit-enforcement machinery that the rest of the package is built on. If you
-touch validation or add a new physical quantity, it happens here.
+## Files
 
-## Modules
-
-### `quantities.py` — the quantity system
-
-The spec is a small **constraint algebra**: a physical identity plus a list of
-pluggable checks. Scalar-vs-array is a *separate* axis (a computer
-representation, not physics) supplied at the annotation site, not stored in the
-spec.
-
-- **`QuantitySpec`** — a frozen dataclass describing one physical quantity:
-  `name`, `default` unit, `equivalencies`, and an ordered
-  `constraints: tuple[Constraint, ...]`. No range/shape fields.
-- **`Constraint` protocol** — any object with
-  `check(quantity, name) -> str | None` (message or `None`). Built-ins:
-  `Range(vmin, vmax)`, `Finite`. Add a new kind by writing a ~4-line frozen
-  dataclass; `check_quantity` never changes.
-- **`Spec` builder** — fluent, terse: `Spec("gain", u.electron/u.adu).ranged(0.1, 100).build()`.
-- **Shape axis** — `ShapeKind` protocol with singletons `SCALAR` / `ARRAY` /
-  `ANY_SHAPE`, and marker *types* `Scalar` / `Array` / `AnyShape` used as the
-  generic subscript (`Time[Scalar]`).
-- **`check_quantity(quantity, spec, shape=ANY_SHAPE)`** — the validator.
-  Raises `TypeError` (not a `Quantity`/`spec`), `ValueError` (incompatible
-  unit). Converts to the default unit, then runs all value-level constraints
-  **and** the shape check, aggregating every failure into one
-  `QuantityValidationError` (a `ValueError` subclass — existing
-  `except ValueError` still catches it).
-- **`_extract_spec(annotation)`** — returns a `(spec, shape)` tuple. Handles a
-  bare generic alias (`Time` → any shape), a subscripted alias
-  (`Time[Scalar]`), a raw `Annotated`, and unions (`Time[Scalar] | None`,
-  both `typing.Union` and PEP 604 `|`). `(None, ANY_SHAPE)` when no spec.
-- The module then defines the canonical `QuantitySpec` constants
-  (`WAVELENGTH`, `AREA`, `GAIN`, `PHOTON_FLUX`, ...) and matching **generic**
-  type aliases via the `type` statement
-  (`type Time[Sh] = Annotated[u.Quantity, TIME, Sh]`, etc.). **These aliases
-  are the public vocabulary** used in every annotated signature across `src/`.
-  Use the bare alias (`Area`) for any-shape, or `Area[Scalar]` / `Area[Array]`
-  to restrict.
-
-### `decorators.py`
-
-- **`enforce_units(func)`** — wraps a callable; binds args, applies defaults,
-  and runs `check_quantity` on every parameter whose hint carries a spec, plus
-  the return value. Uses the `(spec, shape)` pair from `_extract_spec`, so a
-  `Time[Scalar]` hint enforces shape too. Skips `self` and `None` values. Works
-  on functions, methods, and properties (stack `@property` above
-  `@enforce_units`).
-- **`validated_dataclass(**dc_kwargs)`** — a `dataclass` wrapper that also runs
-  `enforce_units` on the generated `__init__`. Used by
-  `photometry.PhotometricParameters`.
-
-### `validation.py`
-
-- **`get_field_value(config, name, dtype)`** — typed accessor for config dicts.
-  Raises `ValueError` for a missing key, `TypeError` for a wrong value/`name`
-  type. Used by the `Pupil._from_config` implementations.
-
-## Adding a new physical quantity (the intended workflow)
-
-1. Add a `QuantitySpec` constant in `quantities.py` with the `Spec` builder
-   (name, default unit, any equivalencies, any value-level constraints such as
-   `.ranged(...)` / `.finite()`).
-2. Add the matching generic alias:
-   `type NewQuantity[Sh] = Annotated[u.Quantity, NEW_QUANTITY, Sh]`.
-3. Annotate parameters/returns with the alias (`NewQuantity` for any shape, or
-   `NewQuantity[Scalar]` / `NewQuantity[Array]`) and decorate with
-   `@enforce_units`. No bespoke unit checking elsewhere.
-
-To add a new *kind of value-level check*, write a small frozen dataclass with a
-`check(quantity, name) -> str | None` method and attach it via the builder's
-`.with_constraint(...)`; `check_quantity` needs no changes.
-
-## Known issues / gotchas
-
-- **`validation.py` f-string lint.** Line ~30 used `f"name must be 'str'"` with
-  no placeholder (flake8 F541) and the missing-field message lacked the quoting
-  the other messages use. Cleaned up on branch
-  `documentation/dev-context-and-cleanup`.
-- **Range limits were dropped during the constraint-algebra refactor.** No
-  catalogue spec currently carries a `Range`; ranges (including the old
-  `QUANTUM_EFFICIENCY` `(1e0, 1e2)` that rejected a physically reasonable
-  `qe < 1.0`) will be reworked per physical quantity on a case-by-case basis.
-  Re-add them with `Spec(...).ranged(vmin, vmax)`.
-- **`PHOTON_FLUX` carries a custom `(u.ph, None)` equivalency** so photons are
-  treated as dimensionless-countable. Anything comparing/parsing photon-flux
-  quantities must pass these equivalencies or conversions will fail.
-- **Shape markers come in two flavours**, easy to mix up: the *types* `Scalar`
-  / `Array` / `AnyShape` are only ever used as the generic subscript
-  (`Time[Scalar]`); the *singletons* `SCALAR` / `ARRAY` / `ANY_SHAPE` are the
-  `ShapeKind` instances passed to `check_quantity` directly. `_extract_spec`
-  maps the former to the latter.
-- **Generic aliases require Python 3.12+** (`type` statement / PEP 695). The
-  repo runs 3.13, and `enforce_units` / `validated_dataclass` already use PEP
-  695 generics, so this is consistent with the codebase.
-- `utils/__init__.py` is empty — import from the submodules by full path
-  (`from metroid.utils.quantities import ...`).
+| File | What | When to read |
+| ---- | ---- | ------------ |
+| `quantities.py` | `QuantitySpec`, `Spec` builder, `Constraint` protocol, `Range` and `Finite` constraint types, `check_quantity` validator, shape markers (`Scalar`, `Array`, `AnyShape`), `_extract_spec`; catalogue of `QuantitySpec` constants and generic type aliases (`Time`, `Area`, `Gain`, etc.) | Adding a new physical quantity or constraint; debugging unit validation errors; understanding how type aliases are resolved |
+| `decorators.py` | `enforce_units` decorator for unit-validating function parameters and return values; `validated_dataclass` wrapper extending enforcement to dataclass `__init__` | Adding `@enforce_units` to a new function or class; debugging decorator behavior; implementing a validated dataclass |
+| `validation.py` | `get_field_value` function for typed extraction from configuration dictionaries | Implementing config-driven construction; debugging missing-field or wrong-type errors in config parsing |
+| `__init__.py` | Empty package init | - |

--- a/src/metroid/utils/README.md
+++ b/src/metroid/utils/README.md
@@ -1,0 +1,82 @@
+# utils
+
+## Overview
+
+The unit-enforcement machinery the rest of the package is built on.
+It provides a small constraint algebra for physical quantities,
+decorator-based enforcement on function parameters and return values,
+and a typed config-dict accessor.
+
+## Architecture
+
+A `QuantitySpec` (`quantities.py`) captures the essential identity of
+a physical quantity: a name, a canonical `astropy` unit, optional unit
+equivalencies, and an ordered tuple of pluggable `Constraint` checks.
+The `Spec` fluent builder keeps catalogue declarations terse (e.g.
+`Spec("gain", u.electron / u.adu).ranged(0.1, 100).build()`).
+
+Scalar-vs-array is a separate axis from the physical spec. Shape
+restrictions are expressed at the annotation site via generic
+subscripts (`Time[Scalar]`, `Time[Array]`) and resolved at runtime by
+`ShapeKind` singletons (`SCALAR`, `ARRAY`, `ANY_SHAPE`).
+
+`check_quantity` converts the quantity to the spec's canonical unit,
+runs every value-level `Constraint`, and runs the shape check. All
+failures are collected and raised together as a single
+`QuantityValidationError` (a `ValueError` subclass).
+
+`_extract_spec` maps a type hint — bare alias (`Time`), subscripted
+alias (`Time[Scalar]`), raw `Annotated`, or union — to a
+`(QuantitySpec, ShapeKind)` pair. This is what makes
+`@enforce_units` annotation-driven.
+
+The catalogue at the bottom of `quantities.py` defines
+`QuantitySpec` constants and matching generic `type` aliases
+(`Time`, `Area`, `Gain`, `Wavelength`, etc.). These aliases are the
+public vocabulary used across the package.
+
+`enforce_units` (`decorators.py`) binds arguments, applies defaults,
+runs `check_quantity` on every annotated parameter, calls the function,
+then validates the return value. `validated_dataclass` extends the same
+enforcement to a dataclass `__init__`.
+
+`get_field_value` (`validation.py`) is a typed accessor for
+configuration dictionaries; it is used by `Pupil._from_config` and
+similar config-driven constructors.
+
+## Design Decisions
+
+**Adding a new physical quantity** follows a three-step workflow:
+(1) add a `QuantitySpec` constant via the `Spec` builder,
+(2) add the matching generic alias
+`type NewQuantity[Sh] = Annotated[u.Quantity, NEW_QUANTITY, Sh]`,
+(3) annotate parameters and return values and decorate the callable
+with `@enforce_units`. No bespoke unit checks are needed elsewhere.
+
+**Adding a new kind of value-level check** requires writing a small
+frozen dataclass with `check(quantity, name) -> str | None` and
+attaching it via `.with_constraint(...)`. The `check_quantity`
+function never changes.
+
+**Range limits are intentionally absent** from the current catalogue.
+An earlier `QUANTUM_EFFICIENCY` range rejected physically reasonable
+values below 1.0 (see closed issue #14). Ranges will be reworked per
+quantity case by case.
+
+## Invariants
+
+Two flavors of shape markers exist and must not be mixed: the marker
+types `Scalar`, `Array`, and `AnyShape` are used only as generic
+subscripts at annotation sites; the singletons `SCALAR`, `ARRAY`, and
+`ANY_SHAPE` are passed as the `shape` argument to `check_quantity`.
+
+`PHOTON_FLUX` carries a custom `(u.ph, None)` equivalency so that
+photons are treated as dimensionless-countable. Any code that
+compares or converts photon flux quantities must supply these
+equivalencies.
+
+Generic type aliases (`type Wavelength[Sh] = ...`) require Python
+3.12+ (PEP 695). The repository targets Python 3.13.
+
+`utils/__init__.py` is empty. Import from submodules by their full
+path (e.g. `from metroid.utils.quantities import Time`).

--- a/src/metroid/utils/quantities.py
+++ b/src/metroid/utils/quantities.py
@@ -1,14 +1,14 @@
 """Physical quantity specifications and runtime validation.
 
-A :class:`QuantitySpec` reduces a physical quantity to its essential
-identity - a name, a canonical unit, and allowed equivalencies - plus an
-ordered list of pluggable :class:`Constraint` objects. Validation converts
+A `QuantitySpec` reduces a physical quantity to its essential
+identity - a name, a canonical unit, and allowed equivalencies - plus
+an ordered list of pluggable `Constraint` objects. Validation converts
 to canonical units once and then runs every value-level constraint,
-aggregating all failures into a single :class:`QuantityValidationError`.
+aggregating all failures into a single `QuantityValidationError`.
 
 New kinds of value-level check are added by writing a small constraint
-class; the core :func:`check_quantity` validator never changes. The fluent
-:class:`Spec` builder keeps the catalogue declarations terse.
+class; the core `check_quantity` validator never changes. The fluent
+`Spec` builder keeps the catalogue declarations terse.
 """
 
 import types
@@ -22,7 +22,7 @@ import numpy as np
 class QuantityValidationError(ValueError):
     """All value-level validation failures for a single quantity, aggregated.
 
-    Subclasses :class:`ValueError`, so existing ``except ValueError``
+    Subclasses `ValueError`, so existing ``except ValueError``
     handlers continue to catch it.
 
     Parameters
@@ -94,7 +94,7 @@ class Finite:
 class ShapeKind(Protocol):
     """A check on the array-shape of a quantity (scalar vs. array).
 
-    Mirrors :class:`Constraint` but is kept distinct so that shape is not
+    Mirrors `Constraint` but is kept distinct so that shape is not
     confused with a physical, value-level constraint.
     """
 
@@ -160,7 +160,7 @@ _SHAPE_BY_MARKER: dict[Any, ShapeKind] = {
 class QuantitySpec:
     """A physical quantity specification - unit identity plus constraints.
 
-    Prefer the fluent :class:`Spec` builder for declarations.
+    Prefer the fluent `Spec` builder for declarations.
 
     Parameters
     ----------
@@ -181,7 +181,7 @@ class QuantitySpec:
 
 
 class Spec:
-    """Fluent builder producing an immutable :class:`QuantitySpec`.
+    """Fluent builder producing an immutable `QuantitySpec`.
 
     Example
     -------
@@ -217,7 +217,7 @@ def check_quantity(quantity: u.Quantity, spec: QuantitySpec, shape: ShapeKind = 
 
     The unit is converted to the spec's canonical unit, then every
     value-level constraint and the shape restriction are run and all
-    failures are aggregated into a single :class:`QuantityValidationError`.
+    failures are aggregated into a single `QuantityValidationError`.
 
     Parameters
     ----------
@@ -264,7 +264,7 @@ def check_quantity(quantity: u.Quantity, spec: QuantitySpec, shape: ShapeKind = 
 
 
 def _spec_from_annotated(annotation: Any) -> QuantitySpec | None:
-    """Pull a :class:`QuantitySpec` out of an ``Annotated[...]`` value."""
+    """Pull a `QuantitySpec` out of an ``Annotated[...]`` value."""
     if get_origin(annotation) is Annotated:
         for meta in get_args(annotation)[1:]:
             if isinstance(meta, QuantitySpec):


### PR DESCRIPTION
## Summary

Reshapes the `metroid` technical documentation to match the project's own documentation guidelines (`.claude/agents/technical-writer.md`), which split code-adjacent docs into three roles: root `CLAUDE.md` = dev patterns (untouched), subdirectory `CLAUDE.md` = navigation index, `README.md` = invisible knowledge.

### Changes
- **Subdirectory `CLAUDE.md` → pure indexes.** The four `src/` subdirectory `CLAUDE.md` files are now tabular `File | What | When to read` indexes; all architecture/invariant/roadmap prose was removed.
- **New `README.md` per subpackage.** `src/metroid`, `photometry`, `utils`, and `profiles` gain README files capturing invisible knowledge (Overview / Architecture / Design Decisions / Invariants).
- **Docstring normalization.** PEP 257 / numpydoc cleanups across `src/`: added `Camera` class docstring, closed inline-terminated docstrings, converted Sphinx roles to backtick markup, fixed typos and a stray colon. No behavior changes.
- **Root `CLAUDE.md`, `CONTRIBUTING.md`, root `README.md`: left untouched** (out of scope by design).

### Gotcha → issue mapping
Every "known issue" removed from the docs maps to a fixed, tracked, or newly-created issue:

| Removed gotcha | Disposition |
| --- | --- |
| `_freeze_filter_response` cache mutation; `int` AB magnitudes; `from_filter_response` mangling | Fixed by merged PR #22 (#19, #20) |
| `validation.py` f-string lint; `__all__` typo | Already clean on `main` |
| Dropped `Range` limits / QE | #14 (closed; intentional) → README design note |
| `RectangularOrbitalObject` missing `@enforce_units` | #13 (open) → README invariant |
| `Observatory` raises `ValueError` on bad type | **new** #23 |
| `Camera.__getitem__` raises `ValueError` not `KeyError` | **new** #24 |
| `Camera` stale `'Bandpass'` message | **new** #25 |
| `sed.py` speclite private-API dependency | **new** #26 |
| `calculate_ab_magnitude`/`_convolve` bypass `@enforce_units` | **new** #27 |
| LEO-object photometry roadmap | **new** #28 |
| photometry float/AB optimization notes | **new** #29 |

### Verification
- `import metroid` and subpackages succeed
- `pytest`: 69 passed
- `black --check src`: clean
- `mypy src`: no new errors (pre-existing missing-stub + validated_dataclass warnings only)

Refs #13 #23 #24 #25 #26 #27 #28 #29

Generated with AI