### PR TITLE
Photometry tech-debt cleanup: skip convolution on AB magnitude flux path (addresses #29)

### DIFF
--- a/src/metroid/photometry/README.md
+++ b/src/metroid/photometry/README.md
@@ -16,13 +16,22 @@ arrays), `from_filter_response` (from an existing `FilterResponse`),
 and `load_filter` (by filter name). Methods on the class
 (`calculate_photon_flux`, `calculate_energy_flux`, `calculate_adu`,
 `calculate_ab_magnitude`) accept a `brightness_spec` that is either a
-`Sed` instance or a numeric AB magnitude. When a numeric magnitude is
-supplied, `_ensure_sed` constructs a flat-AB reference `Sed` and scales
-its flux by `10**(-0.4 * mag)` before convolving.
+`Sed` instance or a numeric AB magnitude. Both flux methods delegate to
+the shared private method `_flux`. When a `Sed` is supplied, `_flux`
+convolves it directly via `_convolve`. When a scalar AB magnitude is
+supplied, convolution is skipped: because convolution is linear in
+spectral flux density, the result is a reference flux scaled by
+`10**(-0.4 * mag)`. For the photon-weighted path the reference flux is
+`ab_zeropoint`; for the energy-weighted path it is
+`_reference_energy_flux`, a `cached_property` that convolves the
+flat-AB reference SED once per instance. The flat-AB reference SED
+itself is built once at the module level by the `_reference_sed()`
+helper (decorated with `lru_cache(maxsize=1)`) and reused across all
+instances and calls.
 
 `Sed` holds a wavelength array and a spectral flux density array
 (`flambda`). The `for_ab_magnitudes()` classmethod builds the flat-AB
-reference SED used internally by `ThroughputCurve._ensure_sed`.
+reference SED consumed by `_reference_sed()`.
 
 `PhotometricParameters` is a frozen, unit-validated dataclass (using
 `validated_dataclass` from `utils/decorators.py`) holding `exptime`,

--- a/src/metroid/photometry/__init__.py
+++ b/src/metroid/photometry/__init__.py
@@ -3,4 +3,4 @@ from .conversions import energy_flux_to_radiance, photon_flux_to_adu
 from .photo_params import PhotometricParameters
 from .sed import Sed
 
-__all__ = ["ThroughputCurve", "energy_flux_to_radiance", "PhotometricParameters", "photon_flux_to_adu", "Sed"]
+__all__ = ["energy_flux_to_radiance", "PhotometricParameters", "photon_flux_to_adu", "Sed", "ThroughputCurve"]

--- a/src/metroid/photometry/photo_params.py
+++ b/src/metroid/photometry/photo_params.py
@@ -1,6 +1,5 @@
 import astropy.units as u
 
-import metroid.utils.quantities as q
 from metroid.utils.decorators import validated_dataclass
 from metroid.utils.quantities import Area, Gain, QuantumEfficiency, Scalar, Time
 

--- a/src/metroid/photometry/sed.py
+++ b/src/metroid/photometry/sed.py
@@ -1,8 +1,8 @@
 from typing import Self
 
 from astropy import units as u
+from astropy.constants import c
 import numpy as np
-from speclite.filters import _ab_constant, validate_wavelength_array
 
 from metroid.utils.decorators import enforce_units
 from metroid.utils.quantities import Array, Wavelength, SpectralFluxDensity
@@ -11,12 +11,18 @@ from metroid.utils.quantities import Array, Wavelength, SpectralFluxDensity
 class Sed:
     """A spectral energy distribution function."""
 
+    _ab_constant = 3631.0 * c * u.Jy
+    """Constant spectral flux density for zero magnitude AB source."""
+
     @enforce_units
     def __init__(self, wavelength: Wavelength[Array], flambda: SpectralFluxDensity[Array]):
         if len(wavelength.value) != len(flambda.value):
             raise ValueError("wavelength and flambda arrays must have same length.")
 
-        self._wavelength = validate_wavelength_array(wavelength, min_length=2) * u.AA
+        if not np.all(np.diff(wavelength.value) > 0):
+            raise ValueError("wavelength values must be strictly increasing.")
+
+        self._wavelength = wavelength
         self._flambda = flambda
 
     @classmethod
@@ -38,7 +44,7 @@ class Sed:
             An instance of `Sed` initialized for AB magnitude calculations.
         """
         wavelength = np.arange(wl_min, wl_max + wl_step, wl_step) * u.nm
-        flambda = (_ab_constant / wavelength**2).to(u.erg / (u.s * u.cm**2 * u.AA))
+        flambda = (cls._ab_constant / wavelength**2).to(u.erg / (u.s * u.cm**2 * u.AA))
 
         return cls(wavelength, flambda)
 

--- a/src/metroid/photometry/throughput.py
+++ b/src/metroid/photometry/throughput.py
@@ -191,6 +191,12 @@ class ThroughputCurve:
         -------
         magnitude : `float`
             The AB magnitude of the object.
+
+        Notes
+        -----
+        AB magnitudes are treated as unitless `float` values, therefore no
+        unit validation is required for this function. This may change in the
+        future, using `astropy.units.ABmag`.
         """
         return self.__fr.get_ab_magnitude(sed.flambda, sed.wavelength)
 

--- a/src/metroid/photometry/throughput.py
+++ b/src/metroid/photometry/throughput.py
@@ -195,7 +195,7 @@ class ThroughputCurve:
         return self.__fr.get_ab_magnitude(sed.flambda, sed.wavelength)
 
     def _ensure_sed(self, brightness_spec: float | int | Sed) -> Sed:
-        """Ensure the correct SED is provided an observed object.
+        """Ensure the correct SED is provided for an observed object.
 
         Parameters
         ----------

--- a/src/metroid/photometry/throughput.py
+++ b/src/metroid/photometry/throughput.py
@@ -1,4 +1,5 @@
 import copy
+import functools
 from typing import Any, Self
 
 import astropy.units as u
@@ -9,6 +10,22 @@ from .photo_params import PhotometricParameters
 from .sed import Sed
 from metroid.utils.decorators import enforce_units
 from metroid.utils.quantities import Adu, Array, EnergyFlux, PhotonFlux, Fraction, Scalar, Wavelength
+
+
+@functools.lru_cache(maxsize=1)
+def _reference_sed() -> Sed:
+    """Return the shared flat-AB reference SED, building it once.
+
+    The reference SED is independent of any throughput curve, so it is
+    constructed a single time and reused across every AB-magnitude
+    calculation rather than being rebuilt on each call.
+
+    Returns
+    -------
+    sed : `metroid.photometry.Sed`
+        The flat-AB reference SED.
+    """
+    return Sed.for_ab_magnitudes()
 
 
 class ThroughputCurve:
@@ -123,8 +140,7 @@ class ThroughputCurve:
         TypeError
             Raised if ``brightness_spec`` is an unsupported type.
         """
-        sed = self._ensure_sed(brightness_spec)
-        return self._convolve(sed, photon_weighted=True)
+        return self._flux(brightness_spec, photon_weighted=True)
 
     @enforce_units
     def calculate_energy_flux(self, brightness_spec: float | int | Sed) -> EnergyFlux[Scalar]:
@@ -147,8 +163,7 @@ class ThroughputCurve:
         TypeError
             Raised if ``brightness_spec`` is an unsupported type.
         """
-        sed = self._ensure_sed(brightness_spec)
-        return self._convolve(sed, photon_weighted=False)
+        return self._flux(brightness_spec, photon_weighted=False)
 
     @enforce_units
     def calculate_adu(
@@ -200,19 +215,28 @@ class ThroughputCurve:
         """
         return self.__fr.get_ab_magnitude(sed.flambda, sed.wavelength)
 
-    def _ensure_sed(self, brightness_spec: float | int | Sed) -> Sed:
-        """Ensure the correct SED is provided for an observed object.
+    def _flux(self, brightness_spec: float | int | Sed, photon_weighted: bool = True) -> u.Quantity:
+        """Calculate a photon- or energy-weighted flux density.
+
+        For an explicit SED the throughput curve is convolved with it
+        directly. For a scalar AB magnitude the convolution is skipped: the
+        convolution is linear in the spectral flux density, so the result is
+        the reference-SED flux scaled by ``10 ** (-0.4 * magnitude)``. The
+        photon-weighted reference flux is the AB zeropoint, and the
+        energy-weighted reference flux is convolved once and cached.
 
         Parameters
         ----------
         brightness_spec : `float`, `int`, or `metroid.photometry.Sed`
             The brightness specification. Can be either an AB magnitude or the
             SED of an observed object.
+        photon_weighted : `bool`, optional
+            Use photon counting weights if `True`, otherwise use unit weights.
 
         Returns
         -------
-        sed : `metroid.photometry.Sed`
-            The SED of the observed object.
+        flux : `astropy.units.Quantity`
+            The photon- or energy-weighted flux density.
 
         Raises
         ------
@@ -220,17 +244,30 @@ class ThroughputCurve:
             Raised if ``brightness_spec`` is an unsupported type.
         """
         if isinstance(brightness_spec, Sed):
-            return brightness_spec
+            return self._convolve(brightness_spec, photon_weighted=photon_weighted)
 
         # ``bool`` subclasses ``int`` but is not a valid magnitude.
         elif isinstance(brightness_spec, (int, float)) and not isinstance(brightness_spec, bool):
-            sed = Sed.for_ab_magnitudes()
-
             scale = 10 ** (-0.4 * brightness_spec)
-            return Sed(sed.wavelength, sed.flambda * scale)
+            reference_flux = self.ab_zeropoint if photon_weighted else self._reference_energy_flux
+            return reference_flux * scale
 
         else:
             raise TypeError("brightness_spec is an unsupported type")
+
+    @functools.cached_property
+    def _reference_energy_flux(self) -> u.Quantity:
+        """The energy-weighted convolution of the flat-AB reference SED.
+
+        Computed once per throughput curve and reused for every scalar
+        AB-magnitude energy flux calculation.
+
+        Returns
+        -------
+        energy_flux : `astropy.units.Quantity`
+            The energy flux density of the flat-AB reference SED.
+        """
+        return self._convolve(_reference_sed(), photon_weighted=False)
 
     def _convolve(self, sed: Sed, photon_weighted: bool = True) -> u.Quantity:
         """Convolve the throughput curve with an SED.

--- a/tests/photometry/test_sed.py
+++ b/tests/photometry/test_sed.py
@@ -23,6 +23,6 @@ def test_sed_creation(sed):
     assert np.allclose(sed.flambda.value, f)
 
 
-def test_for_adu_magnitudes():
+def test_for_ab_magnitudes():
     """Test the creation of a Sed instance for ADU magnitudes."""
     assert isinstance(Sed.for_ab_magnitudes(), Sed)

--- a/tests/photometry/test_throughput.py
+++ b/tests/photometry/test_throughput.py
@@ -44,7 +44,7 @@ def test_calculate_photon_flux(bandpass, brightness_spec):
 
 @pytest.mark.parametrize("brightness_spec", [0.0, Sed.for_ab_magnitudes()])
 def test_calculate_energy_flux(bandpass, brightness_spec):
-    """That that calculate_energy_flux returns correct result for valid
+    """Test that calculate_energy_flux returns correct result for valid
     inputs.
     """
     assert bandpass.calculate_energy_flux(brightness_spec).unit == u.erg / (u.s * u.m**2)


### PR DESCRIPTION
## Summary

Photometry tech-debt cleanup branch. This PR addresses **#29** (photometry float/AB magnitude path optimization) and also carries prior cleanup for #26 and #21.

### Issue #29 changes

The bandpass convolution is linear in the spectral flux density, so a scalar AB magnitude no longer convolves an ~8500-point reference SED:

- [x] **Float/AB path skips convolution.** `calculate_photon_flux(mag)` returns `ab_zeropoint * 10**(-0.4*mag)` directly; `calculate_energy_flux(mag)` scales a cached reference energy flux (convolved once) by `10**(-0.4*mag)`. Both methods now delegate to a shared `_flux` helper (replacing `_ensure_sed`); an explicit `Sed` still convolves directly.
- [x] **Reference SED built once.** A module-level `_reference_sed()` (`functools.lru_cache`) replaces the per-call `Sed.for_ab_magnitudes()`. The energy reference is a per-instance `cached_property`.
- [x] **`_convolve` units — verified NOT redundant, left unchanged.** Confirmed against speclite: passing the `Quantity` with `units=` is the only form that preserves the result units. `.value + units=` drops units (returns bare `np.float64`); the `Quantity` alone raises `ValueError`.

## Verification

- All 69 tests pass (`pytest tests`).
- Float path verified to match the full-SED convolution exactly (photon & energy) for mag 0.0, 15.5, 20.
- `black` clean; `mypy` reports only pre-existing third-party missing-stub warnings.
- README updated to describe the new fast path.

Addresses #29.