### PR TITLE
test(unit): rewrite comprehensive unit tests spanning the package

### DIFF
--- a/tests/photometry/test_conversions.py
+++ b/tests/photometry/test_conversions.py
@@ -1,18 +1,74 @@
-import astropy.units as u
+"""Tests for metroid.photometry.conversions."""
+
+from astropy import units as u
+import pytest
 
 from metroid.photometry.conversions import energy_flux_to_radiance, photon_flux_to_adu
 from metroid.photometry.photo_params import PhotometricParameters
 
+# ---------------------------------------------------------------------------
+# energy_flux_to_radiance
+# ---------------------------------------------------------------------------
 
-def test_energy_flux_to_radiance():
+
+def test_energy_flux_to_radiance_value():
+    """Radiance is the energy flux divided by the solid angle."""
     flux = 1000.0 * u.erg / (u.s * u.m**2)
     solid_angle = 0.001 * u.sr
-    expected_radiance = (flux / solid_angle).to(u.W / u.sr / u.m**2)
-    assert energy_flux_to_radiance(flux, solid_angle) == expected_radiance
+    expected = (flux / solid_angle).to(u.W / u.sr / u.m**2)
+    assert u.isclose(energy_flux_to_radiance(flux, solid_angle), expected)
 
 
-def test_photon_flux_to_adu():
+def test_energy_flux_to_radiance_units():
+    """The result carries radiance units."""
+    result = energy_flux_to_radiance(1000.0 * u.erg / (u.s * u.m**2), 0.001 * u.sr)
+    assert result.unit.is_equivalent(u.W / (u.sr * u.m**2))
+
+
+def test_energy_flux_to_radiance_bad_flux_unit():
+    """A flux with an incompatible unit raises ValueError."""
+    with pytest.raises(ValueError):
+        energy_flux_to_radiance(1000.0 * u.s, 0.001 * u.sr)
+
+
+def test_energy_flux_to_radiance_bad_flux_type():
+    """A non-Quantity flux raises TypeError."""
+    with pytest.raises(TypeError):
+        energy_flux_to_radiance(1000.0, 0.001 * u.sr)
+
+
+# ---------------------------------------------------------------------------
+# photon_flux_to_adu
+# ---------------------------------------------------------------------------
+
+
+def test_photon_flux_to_adu_value():
+    """ADU = photon_flux * exptime * qe * area / gain."""
+    photon_flux = 1000.0 * u.ph / (u.s * u.m**2)
+    photo_params = PhotometricParameters(2.0 * u.s, 4.0 * u.electron / u.adu, 3.0 * u.m**2)
+    # qe defaults to 1 electron/ph: 1000 * 2 * 1 * 3 / 4 = 1500 adu.
+    result = photon_flux_to_adu(photon_flux, photo_params)
+    assert result.unit == u.adu
+    assert result.value == pytest.approx(1500.0)
+
+
+def test_photon_flux_to_adu_default_params():
+    """With unit parameters the ADU equals the incoming photon count."""
     photon_flux = 1000.0 * u.ph / (u.s * u.m**2)
     photo_params = PhotometricParameters(1.0 * u.s, 1.0 * u.electron / u.adu, 1.0 * u.m**2)
-    expected_adu = photon_flux * u.s * u.m**2 * u.adu / u.ph
-    assert photon_flux_to_adu(photon_flux, photo_params) == expected_adu
+    expected = photon_flux * u.s * u.m**2 * u.adu / u.ph
+    assert u.isclose(photon_flux_to_adu(photon_flux, photo_params), expected)
+
+
+def test_photon_flux_to_adu_bad_params_type():
+    """A non-PhotometricParameters second argument raises TypeError."""
+    photon_flux = 1000.0 * u.ph / (u.s * u.m**2)
+    with pytest.raises(TypeError):
+        photon_flux_to_adu(photon_flux, "not params")
+
+
+def test_photon_flux_to_adu_bad_flux_unit():
+    """A photon flux with an incompatible unit raises ValueError."""
+    photo_params = PhotometricParameters(1.0 * u.s, 1.0 * u.electron / u.adu, 1.0 * u.m**2)
+    with pytest.raises(ValueError):
+        photon_flux_to_adu(1000.0 * u.s, photo_params)

--- a/tests/photometry/test_photo_params.py
+++ b/tests/photometry/test_photo_params.py
@@ -1,0 +1,62 @@
+"""Tests for metroid.photometry.photo_params.PhotometricParameters."""
+
+from astropy import units as u
+import pytest
+
+from metroid.photometry.photo_params import PhotometricParameters
+from metroid.utils.quantities import QuantityValidationError
+
+
+def test_photo_params_stores_fields():
+    """Fields are stored and converted to canonical units."""
+    p = PhotometricParameters(
+        exptime=15.0 * u.s,
+        gain=1.5 * u.electron / u.adu,
+        area=0.001 * u.km**2,
+        qe=0.9 * u.electron / u.ph,
+    )
+    assert p.exptime.value == pytest.approx(15.0)
+    assert p.gain.value == pytest.approx(1.5)
+    assert p.area.unit == u.m**2
+    assert p.area.value == pytest.approx(1000.0)
+    assert p.qe.value == pytest.approx(0.9)
+
+
+def test_photo_params_default_qe():
+    """qe defaults to 1 electron per photon."""
+    p = PhotometricParameters(15.0 * u.s, 1.5 * u.electron / u.adu, 1.0 * u.m**2)
+    assert p.qe == 1.0 * u.electron / u.ph
+
+
+def test_photo_params_is_frozen():
+    """PhotometricParameters is immutable."""
+    p = PhotometricParameters(15.0 * u.s, 1.5 * u.electron / u.adu, 1.0 * u.m**2)
+    with pytest.raises(Exception):
+        p.exptime = 20.0 * u.s  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("exptime", 15.0 * u.m),
+        ("gain", 1.5 * u.s),
+        ("area", 1.0 * u.m),
+        ("qe", 0.9 * u.s),
+    ],
+)
+def test_photo_params_bad_unit_raises(field, value):
+    """A field with an incompatible unit raises ValueError."""
+    kwargs = {
+        "exptime": 15.0 * u.s,
+        "gain": 1.5 * u.electron / u.adu,
+        "area": 1.0 * u.m**2,
+    }
+    kwargs[field] = value
+    with pytest.raises(ValueError):
+        PhotometricParameters(**kwargs)
+
+
+def test_photo_params_array_field_rejected():
+    """A Scalar field rejects an array value."""
+    with pytest.raises(QuantityValidationError):
+        PhotometricParameters([1.0, 2.0] * u.s, 1.5 * u.electron / u.adu, 1.0 * u.m**2)

--- a/tests/photometry/test_sed.py
+++ b/tests/photometry/test_sed.py
@@ -1,28 +1,109 @@
-import pytest
+"""Tests for metroid.photometry.sed.Sed."""
+
 from astropy import units as u
 import numpy as np
+import pytest
 
 from metroid.photometry.sed import Sed
+from metroid.utils.quantities import QuantityValidationError
 
 
 @pytest.fixture
 def sed():
-    """A fixture returning a Sed instance."""
+    """A flat Sed over a nanometer wavelength grid."""
     wavelength = np.arange(300.0, 1150.1, 0.1) * u.nm
     flambda = np.ones(len(wavelength)) * u.erg / (u.s * u.cm**2 * u.AA)
     return Sed(wavelength, flambda)
 
 
-def test_sed_creation(sed):
-    """Test the creation of a Sed instance."""
-    wl = np.arange(3000.0, 11501.0, 1.0)
-    f = np.ones(len(wl))
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_sed_wavelength_converted_to_angstrom(sed):
+    """The wavelength array is stored in Angstroms."""
     assert sed.wavelength.unit == u.AA
-    assert np.allclose(sed.wavelength.value, wl)
+    assert np.allclose(sed.wavelength.value, np.arange(3000.0, 11501.0, 1.0))
+
+
+def test_sed_flambda_units(sed):
+    """flambda keeps its spectral-flux-density units."""
     assert sed.flambda.unit == u.erg / (u.s * u.cm**2 * u.AA)
-    assert np.allclose(sed.flambda.value, f)
+    assert np.allclose(sed.flambda.value, 1.0)
 
 
-def test_for_ab_magnitudes():
-    """Test the creation of a Sed instance for ADU magnitudes."""
+def test_sed_length_mismatch_raises():
+    """Mismatched wavelength and flambda lengths raise ValueError."""
+    wavelength = np.array([300.0, 400.0, 500.0]) * u.nm
+    flambda = np.array([1.0, 1.0]) * u.erg / (u.s * u.cm**2 * u.AA)
+    with pytest.raises(ValueError):
+        Sed(wavelength, flambda)
+
+
+def test_sed_non_increasing_wavelength_raises():
+    """A non-strictly-increasing wavelength array raises ValueError."""
+    wavelength = np.array([300.0, 300.0, 500.0]) * u.nm
+    flambda = np.ones(3) * u.erg / (u.s * u.cm**2 * u.AA)
+    with pytest.raises(ValueError):
+        Sed(wavelength, flambda)
+
+
+def test_sed_decreasing_wavelength_raises():
+    """A decreasing wavelength array raises ValueError."""
+    wavelength = np.array([500.0, 400.0, 300.0]) * u.nm
+    flambda = np.ones(3) * u.erg / (u.s * u.cm**2 * u.AA)
+    with pytest.raises(ValueError):
+        Sed(wavelength, flambda)
+
+
+def test_sed_scalar_wavelength_rejected():
+    """A scalar wavelength (Array shape required) raises."""
+    with pytest.raises(QuantityValidationError):
+        Sed(300.0 * u.nm, [1.0] * u.erg / (u.s * u.cm**2 * u.AA))
+
+
+def test_sed_bad_wavelength_unit_rejected():
+    """A wavelength with an incompatible unit raises ValueError."""
+    wavelength = np.array([1.0, 2.0, 3.0]) * u.s
+    flambda = np.ones(3) * u.erg / (u.s * u.cm**2 * u.AA)
+    with pytest.raises(ValueError):
+        Sed(wavelength, flambda)
+
+
+# ---------------------------------------------------------------------------
+# for_ab_magnitudes factory
+# ---------------------------------------------------------------------------
+
+
+def test_for_ab_magnitudes_returns_sed():
+    """for_ab_magnitudes returns a Sed instance."""
     assert isinstance(Sed.for_ab_magnitudes(), Sed)
+
+
+def test_for_ab_magnitudes_default_grid():
+    """The default reference SED spans the documented wavelength grid."""
+    sed = Sed.for_ab_magnitudes()
+    # 300-1150 nm -> 3000-11500 Angstrom.
+    assert sed.wavelength.value.min() == pytest.approx(3000.0)
+    assert sed.wavelength.value.max() == pytest.approx(11500.0)
+
+
+def test_for_ab_magnitudes_custom_grid():
+    """Custom grid bounds and step are honored."""
+    sed = Sed.for_ab_magnitudes(wl_min=400.0, wl_max=700.0, wl_step=1.0)
+    assert sed.wavelength.value.min() == pytest.approx(4000.0)
+    assert sed.wavelength.value.max() == pytest.approx(7000.0)
+
+
+def test_for_ab_magnitudes_flambda_units():
+    """The reference SED's flambda is a spectral flux density."""
+    sed = Sed.for_ab_magnitudes()
+    assert sed.flambda.unit == u.erg / (u.s * u.cm**2 * u.AA)
+
+
+def test_for_ab_magnitudes_flambda_falls_with_wavelength():
+    """The flat-AB reference flambda scales as 1/wavelength^2."""
+    sed = Sed.for_ab_magnitudes()
+    # f_lambda ~ 1/lambda^2, so it is monotonically decreasing.
+    assert np.all(np.diff(sed.flambda.value) < 0)

--- a/tests/photometry/test_throughput.py
+++ b/tests/photometry/test_throughput.py
@@ -1,87 +1,164 @@
-import pytest
+"""Tests for metroid.photometry.throughput.ThroughputCurve."""
+
 from astropy import units as u
 import numpy as np
-
+import pytest
 from speclite.filters import load_filter
-from metroid.photometry import ThroughputCurve, Sed, PhotometricParameters
+
+from metroid.photometry import PhotometricParameters, Sed, ThroughputCurve
 
 
 @pytest.fixture
 def bandpass():
-    """A fixture returning a Camera instance."""
+    """A ThroughputCurve built from the lsst2023-g filter arrays."""
     fr = load_filter("lsst2023-g")
-
     return ThroughputCurve(fr.wavelength * u.AA, fr.response * u.dimensionless_unscaled, fr.meta)
 
 
-def test_bandpass_creation(bandpass):
-    """Test the creation of a Bandpass instance."""
-    fr = load_filter("lsst2023-g")
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
 
+
+def test_init_from_arrays(bandpass):
+    """A curve built from arrays exposes matching wavelength and throughput."""
+    fr = load_filter("lsst2023-g")
     assert u.allclose(bandpass.wavelength, fr.wavelength * u.AA)
-    assert np.allclose(bandpass.throughput, fr.response * u.dimensionless_unscaled)
-    assert bandpass.effective_wavelength.unit == u.AA
-    assert bandpass.ab_zeropoint.unit == u.ph / (u.s * u.m**2)
+    assert np.allclose(bandpass.throughput.value, fr.response)
 
 
 def test_from_filter_response():
+    """from_filter_response builds a ThroughputCurve."""
     fr = load_filter("lsst2023-g")
-
     assert isinstance(ThroughputCurve.from_filter_response(fr), ThroughputCurve)
 
 
+def test_from_filter_response_bad_type():
+    """from_filter_response rejects a non-FilterResponse argument."""
+    with pytest.raises(TypeError):
+        ThroughputCurve.from_filter_response("not a filter response")
+
+
 def test_load_filter():
+    """load_filter builds a ThroughputCurve by name."""
     assert isinstance(ThroughputCurve.load_filter("lsst2023-g"), ThroughputCurve)
 
 
+def test_init_scalar_wavelength_rejected():
+    """A scalar wavelength (Array shape required) raises."""
+    with pytest.raises(Exception):
+        ThroughputCurve(5000.0 * u.AA, 0.5 * u.dimensionless_unscaled, {})
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+
+
+def test_wavelength_units(bandpass):
+    """The wavelength property is in Angstroms."""
+    assert bandpass.wavelength.unit == u.AA
+
+
+def test_throughput_dimensionless(bandpass):
+    """The throughput property is dimensionless."""
+    assert bandpass.throughput.unit == u.dimensionless_unscaled
+
+
+def test_effective_wavelength_units(bandpass):
+    """The effective wavelength is in Angstroms."""
+    assert bandpass.effective_wavelength.unit == u.AA
+
+
+def test_ab_zeropoint_units(bandpass):
+    """The AB zeropoint is a photon flux density."""
+    assert bandpass.ab_zeropoint.unit.is_equivalent(u.ph / (u.s * u.m**2))
+
+
+# ---------------------------------------------------------------------------
+# Flux calculations
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.parametrize("brightness_spec", [0.0, Sed.for_ab_magnitudes()])
-def test_calculate_photon_flux(bandpass, brightness_spec):
-    """Test that calculate_photon_flux returns correct result for valid
-    inputs.
-    """
+def test_calculate_photon_flux_matches_zeropoint(bandpass, brightness_spec):
+    """A zero-magnitude / flat-AB source yields the AB zeropoint photon flux."""
     assert u.isclose(bandpass.calculate_photon_flux(brightness_spec), bandpass.ab_zeropoint)
 
 
+def test_calculate_photon_flux_scales_with_magnitude(bandpass):
+    """Photon flux scales as 10**(-0.4 * mag) relative to the zeropoint."""
+    flux = bandpass.calculate_photon_flux(5.0)
+    assert u.isclose(flux, bandpass.ab_zeropoint * 10 ** (-0.4 * 5.0))
+
+
 @pytest.mark.parametrize("brightness_spec", [0.0, Sed.for_ab_magnitudes()])
-def test_calculate_energy_flux(bandpass, brightness_spec):
-    """Test that calculate_energy_flux returns correct result for valid
-    inputs.
-    """
+def test_calculate_energy_flux_units(bandpass, brightness_spec):
+    """Energy flux is an irradiance in erg/s/m^2."""
     assert bandpass.calculate_energy_flux(brightness_spec).unit == u.erg / (u.s * u.m**2)
 
 
+def test_calculate_energy_flux_scales_with_magnitude(bandpass):
+    """Energy flux scales as 10**(-0.4 * mag) relative to magnitude 0."""
+    ref = bandpass.calculate_energy_flux(0.0)
+    flux = bandpass.calculate_energy_flux(5.0)
+    assert u.isclose(flux, ref * 10 ** (-0.4 * 5.0))
+
+
 @pytest.mark.parametrize("brightness_spec", [0.0, Sed.for_ab_magnitudes()])
-def test_calculate_adu(bandpass, brightness_spec):
+def test_calculate_adu_units(bandpass, brightness_spec):
+    """calculate_adu returns a quantity in ADU."""
     photo_params = PhotometricParameters(1.0 * u.s, 1.0 * u.electron / u.adu, 1.0 * u.m**2)
     assert bandpass.calculate_adu(brightness_spec, photo_params=photo_params).unit == u.adu
 
 
-def test_calculate_ab_magnitude(bandpass):
-    sed = Sed.for_ab_magnitudes()
+def test_calculate_adu_matches_manual_conversion(bandpass):
+    """calculate_adu equals photon_flux_to_adu of the photon flux."""
+    from metroid.photometry.conversions import photon_flux_to_adu
 
-    assert np.isclose(bandpass.calculate_ab_magnitude(sed), 0.0)
+    photo_params = PhotometricParameters(10.0 * u.s, 2.0 * u.electron / u.adu, 5.0 * u.m**2)
+    expected = photon_flux_to_adu(bandpass.calculate_photon_flux(18.0), photo_params)
+    assert u.isclose(bandpass.calculate_adu(18.0, photo_params), expected)
+
+
+def test_calculate_ab_magnitude_of_reference_is_zero(bandpass):
+    """The flat-AB reference SED has AB magnitude ~0 in any band."""
+    assert np.isclose(bandpass.calculate_ab_magnitude(Sed.for_ab_magnitudes()), 0.0)
 
 
 def test_int_magnitude_supported(bandpass):
-    """Regression for #20: int AB magnitudes must be accepted and agree with
-    the equivalent float.
-    """
+    """Regression for #20: int AB magnitudes agree with the float equivalent."""
     assert u.isclose(bandpass.calculate_photon_flux(20), bandpass.calculate_photon_flux(20.0))
     assert u.isclose(bandpass.calculate_energy_flux(20), bandpass.calculate_energy_flux(20.0))
 
 
 def test_bool_magnitude_rejected(bandpass):
-    """``bool`` subclasses ``int`` but is not a valid magnitude."""
+    """bool subclasses int but is not a valid magnitude."""
     with pytest.raises(TypeError):
         bandpass.calculate_photon_flux(True)
 
 
+def test_unsupported_brightness_spec_rejected(bandpass):
+    """A string brightness spec raises TypeError."""
+    with pytest.raises(TypeError):
+        bandpass.calculate_photon_flux("bright")
+
+
+# ---------------------------------------------------------------------------
+# Filter-response ownership
+# ---------------------------------------------------------------------------
+
+
 def test_wrap_does_not_freeze_speclite_cache():
-    """Regression for #19: wrapping a filter must not freeze speclite's shared
-    cached arrays.
-    """
+    """Regression for #19: wrapping must not freeze speclite's shared arrays."""
     ThroughputCurve.load_filter("lsst2023-g")
     fr = load_filter("lsst2023-g")
-
     assert fr.wavelength.flags.writeable
     assert fr.response.flags.writeable
+
+
+def test_owned_arrays_are_frozen(bandpass):
+    """The curve's private filter-response arrays are read-only."""
+    fr = bandpass._ThroughputCurve__fr
+    assert not fr._wavelength.flags.writeable
+    assert not fr._response.flags.writeable

--- a/tests/profiles/test_orbital_objects.py
+++ b/tests/profiles/test_orbital_objects.py
@@ -1,8 +1,10 @@
-import pytest
+"""Tests for metroid.profiles.orbital_objects."""
+
 from astropy import units as u
-from astropy.constants import G, R_earth, M_earth
-import numpy as np
+from astropy.constants import G, M_earth, R_earth
 import galsim
+import numpy as np
+import pytest
 
 from metroid.profiles.orbital_objects import CircularOrbitalObject, RectangularOrbitalObject
 from metroid.profiles.pupils import CircularPupil
@@ -10,37 +12,95 @@ from metroid.profiles.pupils import CircularPupil
 
 @pytest.fixture
 def circular_object():
-    """A fixture returning a CircularOrbitalObject instance."""
+    """A CircularOrbitalObject instance."""
     return CircularOrbitalObject(550.0 * u.km, 70.0 * u.deg, 3.0 * u.m)
 
 
 @pytest.fixture
 def rectangular_object():
-    """A fixture returning a RectangularOrbitalObject instance."""
+    """A RectangularOrbitalObject instance."""
     return RectangularOrbitalObject(550.0 * u.km, 70.0 * u.deg, 2.0 * u.m, 4.0 * u.m)
 
 
 @pytest.fixture
 def orbital_object(request):
-    """A fixture factory returning an OrbitalObject subclass instance."""
+    """An OrbitalObject subclass instance selected by param."""
     if request.param == "circular_object":
         return CircularOrbitalObject(550.0 * u.km, 70.0 * u.deg, 3.0 * u.m)
     elif request.param == "rectangular_object":
         return RectangularOrbitalObject(550.0 * u.km, 70.0 * u.deg, 2.0 * u.m, 4.0 * u.m)
-    else:
-        raise ValueError(f"Unknown pupil type: {request.param}")
+    raise ValueError(f"Unknown object type: {request.param}")
 
 
-@pytest.mark.parametrize(
-    "orbital_object",
-    ["circular_object", "rectangular_object"],
-    indirect=True,
-)
-def test_orbital_object_creation(orbital_object):
-    """Test the creation of an OrbitalObject subclass instance."""
+# ---------------------------------------------------------------------------
+# Construction and stored attributes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("orbital_object", ["circular_object", "rectangular_object"], indirect=True)
+def test_stored_attributes(orbital_object):
+    """Height, zenith/rotation angle, and nadir flag are stored."""
+    assert orbital_object.height == 550.0 * u.km
+    assert orbital_object.zenith_angle == 70.0 * u.deg
+    assert orbital_object.rotation_angle == 0.0 * u.deg
+    assert orbital_object.nadir_pointing is False
+
+
+def test_construction_bad_height_unit():
+    """A height with an incompatible unit raises ValueError."""
+    with pytest.raises(ValueError):
+        CircularOrbitalObject(550.0 * u.s, 70.0 * u.deg, 3.0 * u.m)
+
+
+def test_construction_bad_height_type():
+    """A non-Quantity height raises TypeError."""
+    with pytest.raises(TypeError):
+        CircularOrbitalObject(550.0, 70.0 * u.deg, 3.0 * u.m)
+
+
+# ---------------------------------------------------------------------------
+# Setters
+# ---------------------------------------------------------------------------
+
+
+def test_setters_update_values(circular_object):
+    """Height, zenith angle, and rotation angle setters update the value."""
+    circular_object.height = 600.0 * u.km
+    circular_object.zenith_angle = 45.0 * u.deg
+    circular_object.rotation_angle = 30.0 * u.deg
+    assert circular_object.height == 600.0 * u.km
+    assert circular_object.zenith_angle == 45.0 * u.deg
+    assert circular_object.rotation_angle == 30.0 * u.deg
+
+
+def test_height_setter_validates_unit(circular_object):
+    """The height setter rejects an incompatible unit."""
+    with pytest.raises(ValueError):
+        circular_object.height = 600.0 * u.s
+
+
+def test_nadir_pointing_setter_rejects_non_bool(circular_object):
+    """The nadir_pointing setter rejects a non-bool value."""
+    with pytest.raises(ValueError):
+        circular_object.nadir_pointing = "yes"
+
+
+def test_nadir_pointing_setter_accepts_bool(circular_object):
+    """The nadir_pointing setter accepts a bool."""
+    circular_object.nadir_pointing = True
+    assert circular_object.nadir_pointing is True
+
+
+# ---------------------------------------------------------------------------
+# Orbital mechanics (values checked against the analytic formulas)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("orbital_object", ["circular_object", "rectangular_object"], indirect=True)
+def test_orbital_mechanics(orbital_object):
+    """Derived orbital quantities match their analytic definitions."""
     h = 550.0 * u.km
     theta_z = 70.0 * u.deg
-    theta_r = 0.0 * u.deg
 
     theta_n = np.arcsin(R_earth * np.sin(theta_z) / (R_earth + h)).to(u.deg)
     d = (R_earth * np.sin(theta_z - theta_n) / np.sin(theta_n)).to(u.km)
@@ -50,10 +110,6 @@ def test_orbital_object_creation(orbital_object):
     omega_p = (v_p / d).to(u.rad / u.s, equivalencies=u.dimensionless_angles())
     solid_angle = (orbital_object.area / d**2).to(u.sr, equivalencies=u.dimensionless_angles())
 
-    assert orbital_object.height == h
-    assert orbital_object.zenith_angle == theta_z
-    assert orbital_object.rotation_angle == theta_r
-    assert orbital_object.nadir_pointing is False
     assert u.isclose(orbital_object.nadir_angle, theta_n)
     assert u.isclose(orbital_object.distance, d)
     assert u.isclose(orbital_object.orbital_velocity, v_o)
@@ -63,78 +119,118 @@ def test_orbital_object_creation(orbital_object):
     assert u.isclose(orbital_object.solid_angle, solid_angle)
 
 
-@pytest.mark.parametrize(
-    "orbital_object",
-    ["circular_object", "rectangular_object"],
-    indirect=True,
-)
-def test_calculate_pixel_time_valid(orbital_object):
-    """Test that calculate_pixel_time method of an OrbitalObject subclass
-    instance returns correct result for valid cases.
-    """
+def test_distance_at_zenith_equals_height():
+    """At zenith angle 0 the distance equals the orbital height."""
+    obj = CircularOrbitalObject(550.0 * u.km, 0.0 * u.deg, 3.0 * u.m)
+    assert u.isclose(obj.distance, obj.height)
+
+
+def test_nadir_angle_units(circular_object):
+    """The nadir angle is an angle quantity."""
+    assert circular_object.nadir_angle.unit.is_equivalent(u.deg)
+
+
+# ---------------------------------------------------------------------------
+# calculate_pixel_time
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("orbital_object", ["circular_object", "rectangular_object"], indirect=True)
+def test_calculate_pixel_time(orbital_object):
+    """Pixel traversal time equals pixel_scale / perpendicular angular velocity."""
     pixel_scale = 0.2 * (u.arcsec / u.pix)
-    t_p = (pixel_scale / orbital_object.perpendicular_angular_velocity).to(u.s, equivalencies=[(u.pix, None)])
+    expected = (pixel_scale / orbital_object.perpendicular_angular_velocity).to(
+        u.s, equivalencies=[(u.pix, None)]
+    )
+    assert u.isclose(orbital_object.calculate_pixel_time(pixel_scale), expected)
 
-    assert u.isclose(orbital_object.calculate_pixel_time(pixel_scale), t_p)
 
-
-@pytest.mark.parametrize(
-    "orbital_object",
-    ["circular_object", "rectangular_object"],
-    indirect=True,
-)
-def test_calculate_pixel_time_invalid(orbital_object):
-    """Test that calculate_pixel_time method of an OrbitalObject subclass
-    instance raises proper exception for invalid cases.
-    """
+@pytest.mark.parametrize("orbital_object", ["circular_object", "rectangular_object"], indirect=True)
+def test_calculate_pixel_time_invalid_unit(orbital_object):
+    """A pixel scale with an incompatible unit raises ValueError."""
     with pytest.raises(ValueError):
         orbital_object.calculate_pixel_time(0.2 * (u.s / u.pix))
 
 
-@pytest.mark.parametrize(
-    "orbital_object",
-    ["circular_object", "rectangular_object"],
-    indirect=True,
-)
+# ---------------------------------------------------------------------------
+# get_tracked_profile
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("orbital_object", ["circular_object", "rectangular_object"], indirect=True)
 def test_get_tracked_profile(orbital_object):
-    """Test that get_tracked_profile method of an OrbitalObject subclass
-    instance returns correct result for valid cases.
-    """
+    """get_tracked_profile convolves object, defocus, and PSF."""
     psf = galsim.Kolmogorov(fwhm=0.7)
     pupil = CircularPupil(4.0 * u.m)
-
     assert isinstance(orbital_object.get_tracked_profile(psf, pupil), galsim.Convolution)
 
 
-def test_circular_object_creation(circular_object):
-    """Test the creation of a CircularOrbitalObject instance."""
-    r = 3.0 * u.m
-    area = (np.pi * r**2).to(u.m * u.m)
+def test_get_tracked_profile_bad_pupil(circular_object):
+    """A non-Pupil telescope argument raises TypeError."""
+    psf = galsim.Kolmogorov(fwhm=0.7)
+    with pytest.raises(TypeError):
+        circular_object.get_tracked_profile(psf, "not a pupil")
+
+
+def test_get_tracked_profile_bad_psf(circular_object):
+    """A non-GSObject PSF argument raises TypeError."""
+    pupil = CircularPupil(4.0 * u.m)
+    with pytest.raises(TypeError):
+        circular_object.get_tracked_profile("not a psf", pupil)
+
+
+# ---------------------------------------------------------------------------
+# CircularOrbitalObject
+# ---------------------------------------------------------------------------
+
+
+def test_circular_object_radius_and_area(circular_object):
+    """The radius property and pi*r^2 area are correct."""
+    assert circular_object.radius == 3.0 * u.m
+    assert u.isclose(circular_object.area, np.pi * (3.0 * u.m) ** 2)
+
+
+def test_circular_object_profile(circular_object):
+    """The profile is a TopHat sized by radius/distance in arcsec."""
     expected_radius = (circular_object.radius / circular_object.distance).to_value(
         u.arcsec, equivalencies=u.dimensionless_angles()
     )
-
-    assert circular_object.radius == r
-    assert circular_object.area == area
     assert isinstance(circular_object.profile, galsim.TopHat)
     assert circular_object.profile.radius == pytest.approx(expected_radius)
 
 
-def test_rectangular_object_creation(rectangular_object):
-    """Test the creation of a RectangularOrbitalObject instance."""
-    w = 2.0 * u.m
-    l = 4.0 * u.m
-    area = (w * l).to(u.m * u.m)
+def test_circular_object_nadir_pointing_projects_profile():
+    """A nadir-pointing circular object returns a transformed profile."""
+    obj = CircularOrbitalObject(550.0 * u.km, 70.0 * u.deg, 3.0 * u.m, nadir_pointing=True)
+    assert isinstance(obj.profile, galsim.GSObject)
+
+
+# ---------------------------------------------------------------------------
+# RectangularOrbitalObject
+# ---------------------------------------------------------------------------
+
+
+def test_rectangular_object_dimensions_and_area(rectangular_object):
+    """The width/length properties and w*l area are correct."""
+    assert rectangular_object.width == 2.0 * u.m
+    assert rectangular_object.length == 4.0 * u.m
+    assert u.isclose(rectangular_object.area, (2.0 * u.m) * (4.0 * u.m))
+
+
+def test_rectangular_object_profile(rectangular_object):
+    """The profile is a Box sized by width/length over distance in arcsec."""
     expected_width = (rectangular_object.width / rectangular_object.distance).to_value(
         u.arcsec, equivalencies=u.dimensionless_angles()
     )
     expected_length = (rectangular_object.length / rectangular_object.distance).to_value(
         u.arcsec, equivalencies=u.dimensionless_angles()
     )
-
-    assert rectangular_object.width == w
-    assert rectangular_object.length == l
-    assert rectangular_object.area == area
     assert isinstance(rectangular_object.profile, galsim.Box)
     assert rectangular_object.profile.width == pytest.approx(expected_width)
     assert rectangular_object.profile.height == pytest.approx(expected_length)
+
+
+def test_rectangular_object_nadir_pointing_projects_profile():
+    """A nadir-pointing rectangular object returns a transformed profile."""
+    obj = RectangularOrbitalObject(550.0 * u.km, 70.0 * u.deg, 2.0 * u.m, 4.0 * u.m, nadir_pointing=True)
+    assert isinstance(obj.profile, galsim.GSObject)

--- a/tests/profiles/test_pupils.py
+++ b/tests/profiles/test_pupils.py
@@ -1,31 +1,38 @@
-import pytest
+"""Tests for metroid.profiles.pupils."""
+
 from astropy import units as u
 import galsim
+import numpy as np
+import pytest
 
-from metroid.profiles.pupils import Pupil, CircularPupil, AnnularPupil
+from metroid.profiles.pupils import AnnularPupil, CircularPupil, Pupil
 
 
 @pytest.fixture
 def circular_pupil():
-    """A fixture returning a CircularPupil instance."""
+    """A CircularPupil instance."""
     return CircularPupil(4.0 * u.m)
 
 
 @pytest.fixture
 def annular_pupil():
-    """A fixture returning an AnnularPupil instance."""
+    """An AnnularPupil instance."""
     return AnnularPupil(1.0 * u.m, 4.0 * u.m)
 
 
 @pytest.fixture
 def pupil(request):
-    """A fixture factory returning a Pupil subclass instance."""
+    """A Pupil subclass instance selected by param."""
     if request.param == "circular_pupil":
         return CircularPupil(4.0 * u.m)
     elif request.param == "annular_pupil":
         return AnnularPupil(1.0 * u.m, 4.0 * u.m)
-    else:
-        raise ValueError(f"Unknown pupil type: {request.param}")
+    raise ValueError(f"Unknown pupil type: {request.param}")
+
+
+# ---------------------------------------------------------------------------
+# from_config registry dispatch
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -35,37 +42,56 @@ def pupil(request):
         ({"type": "annular", "inner_radius": 1.0, "outer_radius": 4.0}, AnnularPupil),
     ],
 )
-def test_from_config(config, expected_type):
-    """Test the creation of Pupil subclass instance from a configuration
-    dictionary.
-    """
+def test_from_config_dispatch(config, expected_type):
+    """from_config builds the subclass named by the 'type' field."""
     pupil = Pupil.from_config(config)
     assert isinstance(pupil, expected_type)
 
 
-@pytest.mark.parametrize(
-    "pupil",
-    ["circular_pupil", "annular_pupil"],
-    indirect=True,
-)
-@pytest.mark.parametrize(
-    "distance,expected_exception",
-    [
-        ("not a quantity", TypeError),
-        (50.0 * u.s, ValueError),
-    ],
-)
-def test_get_profile_invalid(pupil, distance, expected_exception):
-    """Test that get_profile method of a Pupil subclass instance raises proper
-    exception for invalid cases.
-    """
-    with pytest.raises(expected_exception):
-        pupil.get_profile(distance)
+def test_from_config_values(circular_pupil):
+    """from_config passes field values through to the constructor."""
+    pupil = Pupil.from_config({"type": "circular", "radius": 4.0})
+    assert pupil.radius == 4.0 * u.m
 
 
-def test_circular_pupil_creation(circular_pupil):
-    """Test the creation of a CircularPupil instance."""
+def test_from_config_missing_type_raises():
+    """A config lacking 'type' raises ValueError."""
+    with pytest.raises(ValueError):
+        Pupil.from_config({"radius": 4.0})
+
+
+def test_from_config_unknown_type_raises():
+    """An unknown pupil type raises ValueError."""
+    with pytest.raises(ValueError):
+        Pupil.from_config({"type": "triangular", "radius": 4.0})
+
+
+def test_from_config_does_not_mutate_input():
+    """from_config copies the config and leaves the caller's dict intact."""
+    config = {"type": "circular", "radius": 4.0}
+    Pupil.from_config(config)
+    assert config == {"type": "circular", "radius": 4.0}
+
+
+def test_from_config_missing_field_raises():
+    """A config missing a required subclass field raises ValueError."""
+    with pytest.raises(ValueError):
+        Pupil.from_config({"type": "circular"})
+
+
+# ---------------------------------------------------------------------------
+# CircularPupil
+# ---------------------------------------------------------------------------
+
+
+def test_circular_pupil_radius(circular_pupil):
+    """The radius property returns the constructed value."""
     assert circular_pupil.radius == 4.0 * u.m
+
+
+def test_circular_pupil_area(circular_pupil):
+    """The area is pi * radius^2."""
+    assert u.isclose(circular_pupil.area, np.pi * (4.0 * u.m) ** 2)
 
 
 @pytest.mark.parametrize(
@@ -75,34 +101,38 @@ def test_circular_pupil_creation(circular_pupil):
         (4.0 * u.s, ValueError),
     ],
 )
-def test_circular_pupil_creation_invalid(radius, expected_error):
-    """Test that creation of a CircularPupil raises proper exception for
-    invalid cases.
-    """
+def test_circular_pupil_invalid(radius, expected_error):
+    """A bad radius type or unit raises on construction."""
     with pytest.raises(expected_error):
         CircularPupil(radius)
 
 
-def test_circular_get_profile_valid(circular_pupil):
-    """Test that get_profile method of a CircularPupil instance returns
-    correct result for valid cases.
-    """
+def test_circular_get_profile(circular_pupil):
+    """get_profile returns a TopHat sized by radius/distance in arcsec."""
     distance = 200.0 * u.km
     profile = circular_pupil.get_profile(distance)
-
     assert isinstance(profile, galsim.TopHat)
-
     expected_radius = (circular_pupil.radius / distance).to_value(
         u.arcsec, equivalencies=u.dimensionless_angles()
     )
-
     assert profile.radius == pytest.approx(expected_radius)
 
 
-def test_annular_pupil_creation(annular_pupil):
-    """Test the creation of an AnnularPupil instance."""
+# ---------------------------------------------------------------------------
+# AnnularPupil
+# ---------------------------------------------------------------------------
+
+
+def test_annular_pupil_radii(annular_pupil):
+    """The inner and outer radius properties return constructed values."""
     assert annular_pupil.inner_radius == 1.0 * u.m
     assert annular_pupil.outer_radius == 4.0 * u.m
+
+
+def test_annular_pupil_area(annular_pupil):
+    """The area is pi * (outer^2 - inner^2)."""
+    expected = np.pi * ((4.0 * u.m) ** 2 - (1.0 * u.m) ** 2)
+    assert u.isclose(annular_pupil.area, expected)
 
 
 @pytest.mark.parametrize(
@@ -111,34 +141,47 @@ def test_annular_pupil_creation(annular_pupil):
         (1.0, 4.0 * u.m, TypeError),
         (1.0 * u.m, 4.0, TypeError),
         (4.0 * u.m, 4.0 * u.m, ValueError),
+        (5.0 * u.m, 4.0 * u.m, ValueError),
     ],
 )
-def test_annular_pupil_creation_invalid(inner_radius, outer_radius, expected_error):
-    """Test that creation of an AnnularPupil instance raises proper
-    exception for invalid cases.
-    """
+def test_annular_pupil_invalid(inner_radius, outer_radius, expected_error):
+    """Bad radius types, or outer <= inner, raise on construction."""
     with pytest.raises(expected_error):
         AnnularPupil(inner_radius, outer_radius)
 
 
-def test_annular_get_profile_valid(annular_pupil):
-    """Test that get_profile method of an AnnularPupil instance returns
-    correct result for valid cases.
-    """
+def test_annular_get_profile(annular_pupil):
+    """get_profile returns a difference of TopHats scaled by (r_i/r_o)^2."""
     distance = 200.0 * u.km
     profile = annular_pupil.get_profile(distance)
-
     assert isinstance(profile, galsim.Sum)
 
     obj_list = profile.obj_list
-    expected_inner_radius = (annular_pupil.inner_radius / distance).to_value(
+    expected_inner = (annular_pupil.inner_radius / distance).to_value(
         u.arcsec, equivalencies=u.dimensionless_angles()
     )
-    expected_outer_radius = (annular_pupil.outer_radius / distance).to_value(
+    expected_outer = (annular_pupil.outer_radius / distance).to_value(
         u.arcsec, equivalencies=u.dimensionless_angles()
     )
-    expected_flux = 1.0
+    assert obj_list[0].radius == pytest.approx(expected_outer)
+    assert obj_list[1].original.radius == pytest.approx(expected_inner)
+    assert obj_list[1].flux == pytest.approx(-((expected_inner / expected_outer) ** 2))
 
-    assert obj_list[0].radius == pytest.approx(expected_outer_radius)
-    assert obj_list[1].original.radius == pytest.approx(expected_inner_radius)
-    assert obj_list[1].flux == -((expected_inner_radius / expected_outer_radius) ** 2)
+
+# ---------------------------------------------------------------------------
+# Shared get_profile validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("pupil", ["circular_pupil", "annular_pupil"], indirect=True)
+@pytest.mark.parametrize(
+    "distance,expected_error",
+    [
+        ("not a quantity", TypeError),
+        (50.0 * u.s, ValueError),
+    ],
+)
+def test_get_profile_invalid(pupil, distance, expected_error):
+    """A bad distance type or unit raises."""
+    with pytest.raises(expected_error):
+        pupil.get_profile(distance)

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -1,26 +1,53 @@
-import pytest
+"""Tests for metroid.camera.Camera."""
+
 from astropy import units as u
 import numpy as np
+import pytest
 
 from metroid.camera import Camera
 from metroid.photometry import ThroughputCurve
 
 
 @pytest.fixture
-def camera():
-    """A fixture returning a Camera instance."""
-    gain = 1.5 * (u.electron / u.adu)
-    pixel_scale = 0.2 * (u.arcsec / u.pix)
-    bandpasses = {"lsst2023-u": ThroughputCurve.load_filter("lsst2023-u")}
-    return Camera(bandpasses, gain, pixel_scale)
+def bandpasses():
+    """A mapping of one named ThroughputCurve."""
+    return {"lsst2023-u": ThroughputCurve.load_filter("lsst2023-u")}
 
 
-def test_camera_creation(camera):
-    """Test the creation of a Camera instance."""
-    assert camera.qe == 1.0 * u.electron / u.ph
+@pytest.fixture
+def camera(bandpasses):
+    """A Camera instance with default QE."""
+    return Camera(bandpasses, 1.5 * (u.electron / u.adu), 0.2 * (u.arcsec / u.pix))
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_camera_stores_properties(camera):
+    """A Camera exposes its gain, pixel scale, and default QE."""
     assert camera.gain == 1.5 * (u.electron / u.adu)
     assert camera.pixel_scale == 0.2 * (u.arcsec / u.pix)
-    assert camera.filter_names == ("lsst2023-u",)
+    assert camera.qe == 1.0 * u.electron / u.ph
+
+
+def test_camera_explicit_qe(bandpasses):
+    """An explicit QE is stored on the camera."""
+    camera = Camera(
+        bandpasses,
+        1.5 * (u.electron / u.adu),
+        0.2 * (u.arcsec / u.pix),
+        qe=0.8 * u.electron / u.ph,
+    )
+    assert camera.qe == 0.8 * u.electron / u.ph
+
+
+def test_camera_converts_units(bandpasses):
+    """Constructor arguments are converted to canonical units."""
+    camera = Camera(bandpasses, 1.5 * (u.electron / u.adu), 200.0 * (u.marcsec / u.pix))
+    assert camera.pixel_scale.unit == u.arcsec / u.pix
+    assert camera.pixel_scale.value == pytest.approx(0.2)
 
 
 @pytest.mark.parametrize(
@@ -28,31 +55,77 @@ def test_camera_creation(camera):
     [
         (1.5, 0.2 * (u.arcsec / u.pix), TypeError),
         (1.5 * (u.electron / u.adu), 0.2, TypeError),
+        (1.5 * u.s, 0.2 * (u.arcsec / u.pix), ValueError),
+        (1.5 * (u.electron / u.adu), 0.2 * u.s, ValueError),
     ],
 )
-def test_camera_creation_invalid(gain, pixel_scale, expected_error):
-    """Test that creation of a Camera raises proper exception for invalid
-    cases.
-    """
-    bandpasses = {"lsst2023-u": ThroughputCurve.load_filter("lsst2023-u")}
+def test_camera_creation_invalid(bandpasses, gain, pixel_scale, expected_error):
+    """Bad gain/pixel-scale types or units raise on construction."""
     with pytest.raises(expected_error):
         Camera(bandpasses, gain, pixel_scale)
 
 
-def test_get_bandpass_valid(camera):
-    """Test that get_bandpass method of a Camera instance returns correct
-    result for valid cases.
-    """
-    expected_bandpass = ThroughputCurve.load_filter("lsst2023-u")
+def test_camera_rejects_non_string_key():
+    """A non-string bandpass key raises TypeError."""
+    bandpasses = {1: ThroughputCurve.load_filter("lsst2023-u")}
+    with pytest.raises(TypeError):
+        Camera(bandpasses, 1.5 * (u.electron / u.adu), 0.2 * (u.arcsec / u.pix))
+
+
+def test_camera_rejects_non_throughput_value():
+    """A bandpass value that is not a ThroughputCurve raises TypeError."""
+    bandpasses = {"lsst2023-u": "not a curve"}
+    with pytest.raises(TypeError):
+        Camera(bandpasses, 1.5 * (u.electron / u.adu), 0.2 * (u.arcsec / u.pix))
+
+
+# ---------------------------------------------------------------------------
+# Mapping interface
+# ---------------------------------------------------------------------------
+
+
+def test_filter_names(camera):
+    """filter_names returns a tuple of the bandpass names."""
+    assert camera.filter_names == ("lsst2023-u",)
+
+
+def test_getitem_returns_bandpass(camera):
+    """Indexing by name returns the stored ThroughputCurve."""
     bandpass = camera["lsst2023-u"]
+    assert isinstance(bandpass, ThroughputCurve)
+    expected = ThroughputCurve.load_filter("lsst2023-u")
+    assert np.allclose(bandpass.wavelength.value, expected.wavelength.value)
+    assert np.allclose(bandpass.throughput.value, expected.throughput.value)
 
-    assert np.allclose(bandpass.wavelength.value, expected_bandpass.wavelength.value)
-    assert np.allclose(bandpass.throughput.value, expected_bandpass.throughput.value)
 
-
-def test_get_bandpass_invalid(camera):
-    """Test that get_bandpass method of a Camera instance raises proper
-    exception for invalid cases.
-    """
+def test_getitem_unknown_raises_value_error(camera):
+    """Indexing by an unknown name raises ValueError."""
     with pytest.raises(ValueError):
         camera["unknown"]
+
+
+def test_len(camera):
+    """len reports the number of bandpasses."""
+    assert len(camera) == 1
+
+
+def test_iter(camera):
+    """Iterating a Camera yields its bandpass names."""
+    assert list(camera) == ["lsst2023-u"]
+
+
+def test_multiple_bandpasses():
+    """A Camera holds and reports multiple named bandpasses."""
+    bandpasses = {
+        "lsst2023-u": ThroughputCurve.load_filter("lsst2023-u"),
+        "lsst2023-g": ThroughputCurve.load_filter("lsst2023-g"),
+    }
+    camera = Camera(bandpasses, 1.5 * (u.electron / u.adu), 0.2 * (u.arcsec / u.pix))
+    assert len(camera) == 2
+    assert set(camera.filter_names) == {"lsst2023-u", "lsst2023-g"}
+
+
+def test_bandpasses_are_read_only(camera):
+    """The internal bandpass mapping does not support item assignment."""
+    with pytest.raises(TypeError):
+        camera._bandpasses["x"] = None  # type: ignore[index]

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -1,36 +1,105 @@
-import pytest
+"""Tests for metroid.observatory.Observatory."""
+
 from astropy import units as u
 from astropy.coordinates import EarthLocation
 import numpy as np
+import pytest
 
-from metroid.observatory import Observatory
-from metroid.profiles import CircularPupil
 from metroid.camera import Camera
-from metroid.photometry import Sed, ThroughputCurve
+from metroid.observatory import Observatory
+from metroid.photometry import PhotometricParameters, ThroughputCurve
+from metroid.profiles import CircularPupil
 
 
 @pytest.fixture
-def observatory():
-    """A fixture returning an Observatory instance."""
+def camera():
+    """A Camera instance."""
     bandpasses = {"lsst2023-u": ThroughputCurve.load_filter("lsst2023-u")}
-    camera = Camera(bandpasses, 1.5 * (u.electron / u.adu), 0.2 * (u.arcsec / u.pix))
-    pupil = CircularPupil(4.0 * u.m)
-    location = EarthLocation.of_site("Rubin")
+    return Camera(bandpasses, 1.5 * (u.electron / u.adu), 0.2 * (u.arcsec / u.pix))
 
+
+@pytest.fixture
+def pupil():
+    """A CircularPupil instance."""
+    return CircularPupil(4.0 * u.m)
+
+
+@pytest.fixture
+def location():
+    """A fixed EarthLocation (avoids a network site lookup)."""
+    return EarthLocation.from_geodetic(lon=-70.7494 * u.deg, lat=-30.2446 * u.deg, height=2647.0 * u.m)
+
+
+@pytest.fixture
+def observatory(camera, pupil, location):
+    """An Observatory instance."""
     return Observatory(camera, pupil, location)
 
 
-def test_observatory_creation(observatory):
-    """Test the creation of an Observatory instance."""
-    assert isinstance(observatory.camera, Camera)
-    assert isinstance(observatory.pupil, CircularPupil)
-    assert isinstance(observatory.location, EarthLocation)
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
 
 
-def test_get_photo_params(observatory):
-    """Test that get_photo_params returns the correct result for valid inputs."""
+def test_observatory_stores_components(observatory, camera, pupil, location):
+    """The observatory exposes its camera, pupil, and location."""
+    assert observatory.camera is camera
+    assert observatory.pupil is pupil
+    assert observatory.location is location
+
+
+@pytest.mark.parametrize(
+    "bad_camera",
+    ["not a camera", None, 42],
+)
+def test_observatory_rejects_bad_camera(bad_camera, pupil, location):
+    """A non-Camera first argument raises ValueError."""
+    with pytest.raises(ValueError):
+        Observatory(bad_camera, pupil, location)
+
+
+def test_observatory_rejects_bad_pupil(camera, location):
+    """A non-Pupil second argument raises ValueError."""
+    with pytest.raises(ValueError):
+        Observatory(camera, "not a pupil", location)
+
+
+def test_observatory_rejects_bad_location(camera, pupil):
+    """A non-EarthLocation third argument raises ValueError."""
+    with pytest.raises(ValueError):
+        Observatory(camera, pupil, "not a location")
+
+
+# ---------------------------------------------------------------------------
+# get_photo_params
+# ---------------------------------------------------------------------------
+
+
+def test_get_photo_params_returns_parameters(observatory):
+    """get_photo_params builds PhotometricParameters from the components."""
     photo_params = observatory.get_photo_params(15.0 * u.s)
+    assert isinstance(photo_params, PhotometricParameters)
     assert photo_params.exptime.value == pytest.approx(15.0)
     assert photo_params.gain.value == pytest.approx(1.5)
     assert photo_params.area.value == pytest.approx(np.pi * 4.0**2)
     assert photo_params.qe.value == pytest.approx(1.0)
+
+
+def test_get_photo_params_converts_exptime_unit(observatory):
+    """A non-canonical exposure-time unit is converted to seconds."""
+    photo_params = observatory.get_photo_params(0.25 * u.min)
+    assert photo_params.exptime.unit == u.s
+    assert photo_params.exptime.value == pytest.approx(15.0)
+
+
+@pytest.mark.parametrize(
+    "exptime,expected_error",
+    [
+        (15.0, TypeError),
+        (15.0 * u.m, ValueError),
+    ],
+)
+def test_get_photo_params_invalid_exptime(observatory, exptime, expected_error):
+    """A bad exposure-time type or unit raises."""
+    with pytest.raises(expected_error):
+        observatory.get_photo_params(exptime)

--- a/tests/utils/test_decorators.py
+++ b/tests/utils/test_decorators.py
@@ -1,18 +1,60 @@
+"""Tests for metroid.utils.decorators."""
+
 from astropy import units as u
 import numpy as np
 import pytest
 
-from metroid.utils.decorators import enforce_units
-from metroid.utils.quantities import Array, GeometryLength, Area, QuantityValidationError, Scalar, Time
+from metroid.utils.decorators import enforce_units, validated_dataclass
+from metroid.utils.quantities import (
+    Area,
+    Array,
+    GeometryLength,
+    QuantityValidationError,
+    Scalar,
+    Time,
+)
+
+# ---------------------------------------------------------------------------
+# enforce_units: argument and return validation
+# ---------------------------------------------------------------------------
 
 
-def test_enforce_units():
+def test_enforce_units_validates_argument_unit():
+    """An argument with an incompatible unit raises ValueError."""
+
+    @enforce_units
+    def f(length: GeometryLength) -> GeometryLength:
+        return length
+
+    assert f(5.0 * u.m).unit == u.m
+    with pytest.raises(ValueError):
+        f(5.0 * u.s)
+
+
+def test_enforce_units_converts_argument_to_canonical_unit():
+    """An argument is converted to the spec's canonical unit before the body."""
+
+    @enforce_units
+    def get_value(length: GeometryLength) -> float:
+        return length.value
+
+    # 5 km -> 5000 m
+    assert get_value(5.0 * u.km) == pytest.approx(5000.0)
+
+
+def test_enforce_units_validates_return_unit():
+    """The return value is validated and converted to canonical units."""
 
     @enforce_units
     def area(radius: GeometryLength) -> Area:
         return np.pi * radius**2
 
-    assert area(5.0 * u.m).unit == (u.m**2)
+    result = area(5.0 * u.m)
+    assert result.unit == u.m**2
+
+
+def test_enforce_units_converts_return_to_canonical_unit():
+    """A return value in a non-canonical unit is converted."""
 
     @enforce_units
     def quantify(radius: float) -> GeometryLength:
@@ -20,27 +62,68 @@ def test_enforce_units():
 
     assert quantify(0.010).unit == u.m
 
-    @enforce_units
-    def get_value(radius: GeometryLength) -> float:
-        return radius.value
 
-    assert get_value(5.0 * u.m) == 5.0
+def test_enforce_units_untyped_argument_passed_through():
+    """An argument without a quantity annotation is not validated."""
 
     @enforce_units
-    def null_return1(radius: GeometryLength) -> None:
+    def quantify(radius: float) -> GeometryLength:
+        return radius * u.km
+
+    # A plain float is accepted, since ``radius`` carries no QuantitySpec.
+    assert quantify(2.0).value == pytest.approx(2000.0)
+
+
+def test_enforce_units_none_return_annotation():
+    """A ``-> None`` annotation skips return validation."""
+
+    @enforce_units
+    def f(length: GeometryLength) -> None:
         return None
 
-    assert null_return1(5.0 * u.m) is None
+    assert f(5.0 * u.m) is None
+
+
+def test_enforce_units_missing_return_annotation():
+    """A missing return annotation skips return validation."""
 
     @enforce_units
-    def null_return2(length: GeometryLength):
+    def f(length: GeometryLength):
         return None
 
-    assert null_return2(5.0 * u.m) is None
+    assert f(5.0 * u.m) is None
 
 
-def test_enforce_units_shape():
-    """Test that generic shape aliases are enforced through the decorator."""
+def test_enforce_units_none_argument_skipped():
+    """A ``None`` argument value skips validation of that parameter."""
+
+    @enforce_units
+    def f(length: GeometryLength | None = None) -> float:
+        return -1.0 if length is None else length.value
+
+    assert f() == -1.0
+    assert f(5.0 * u.m) == pytest.approx(5.0)
+
+
+def test_enforce_units_preserves_metadata():
+    """functools.wraps preserves the wrapped function's name and docstring."""
+
+    @enforce_units
+    def my_func(length: GeometryLength) -> GeometryLength:
+        """Docstring."""
+        return length
+
+    assert my_func.__name__ == "my_func"
+    assert my_func.__doc__ == "Docstring."
+
+
+# ---------------------------------------------------------------------------
+# enforce_units: shape enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_enforce_units_scalar_shape():
+    """A Scalar-annotated parameter rejects arrays."""
 
     @enforce_units
     def needs_scalar(t: Time[Scalar]) -> Time[Scalar]:
@@ -50,6 +133,10 @@ def test_enforce_units_shape():
     with pytest.raises(QuantityValidationError):
         needs_scalar([1.0, 2.0] * u.s)
 
+
+def test_enforce_units_array_shape():
+    """An Array-annotated parameter rejects scalars."""
+
     @enforce_units
     def needs_array(t: Time[Array]) -> Time[Array]:
         return t
@@ -58,9 +145,80 @@ def test_enforce_units_shape():
     with pytest.raises(QuantityValidationError):
         needs_array(5.0 * u.s)
 
+
+def test_enforce_units_any_shape():
+    """A bare alias imposes no shape restriction."""
+
     @enforce_units
     def any_shape(t: Time) -> Time:
         return t
 
     assert any_shape(5.0 * u.s).unit == u.s
     assert any_shape([1.0, 2.0] * u.s).unit == u.s
+
+
+def test_enforce_units_keyword_and_default_arguments():
+    """Defaults are applied and keyword arguments are validated."""
+
+    @enforce_units
+    def f(a: Time, b: Time = 2.0 * u.s) -> Time:
+        return a + b
+
+    assert f(1.0 * u.s).value == pytest.approx(3.0)
+    assert f(a=1.0 * u.s, b=4.0 * u.s).value == pytest.approx(5.0)
+    # A bad-unit default-overriding keyword is still validated.
+    with pytest.raises(ValueError):
+        f(1.0 * u.s, b=2.0 * u.m)
+
+
+# ---------------------------------------------------------------------------
+# validated_dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_validated_dataclass_validates_and_converts():
+    """A validated dataclass enforces and converts field units at init."""
+
+    @validated_dataclass(frozen=True)
+    class Params:
+        exptime: Time[Scalar]
+        area: Area[Scalar]
+
+    p = Params(exptime=15.0 * u.s, area=0.001 * u.km**2)
+    assert p.exptime.unit == u.s
+    assert p.area.unit == u.m**2
+    assert p.area.value == pytest.approx(1000.0)
+
+
+def test_validated_dataclass_rejects_bad_unit():
+    """A field with an incompatible unit raises ValueError at construction."""
+
+    @validated_dataclass(frozen=True)
+    class Params:
+        exptime: Time[Scalar]
+
+    with pytest.raises(ValueError):
+        Params(exptime=15.0 * u.m)
+
+
+def test_validated_dataclass_rejects_bad_shape():
+    """A Scalar field rejects an array value at construction."""
+
+    @validated_dataclass(frozen=True)
+    class Params:
+        exptime: Time[Scalar]
+
+    with pytest.raises(QuantityValidationError):
+        Params(exptime=[1.0, 2.0] * u.s)
+
+
+def test_validated_dataclass_honors_frozen_kwarg():
+    """The frozen dataclass keyword is forwarded, making instances immutable."""
+
+    @validated_dataclass(frozen=True)
+    class Params:
+        exptime: Time[Scalar]
+
+    p = Params(exptime=15.0 * u.s)
+    with pytest.raises(Exception):
+        p.exptime = 20.0 * u.s  # type: ignore[misc]

--- a/tests/utils/test_quantities.py
+++ b/tests/utils/test_quantities.py
@@ -1,4 +1,7 @@
+"""Tests for metroid.utils.quantities."""
+
 from astropy import units as u
+import numpy as np
 import pytest
 
 from metroid.utils.quantities import (
@@ -6,80 +9,310 @@ from metroid.utils.quantities import (
     AREA,
     ARRAY,
     SCALAR,
+    TIME,
+    AnyShape,
     Area,
     Array,
+    Constraint,
+    Finite,
     QuantitySpec,
     QuantityValidationError,
+    Range,
     Scalar,
+    ShapeKind,
+    SOLID_ANGLE,
     Spec,
-    TIME,
+    Time,
     check_quantity,
     _extract_spec,
+    _spec_from_annotated,
 )
 
+# ---------------------------------------------------------------------------
+# QuantityValidationError
+# ---------------------------------------------------------------------------
 
-def test_quantity_spec_creation():
+
+def test_validation_error_is_value_error():
+    """QuantityValidationError subclasses ValueError."""
+    assert issubclass(QuantityValidationError, ValueError)
+
+
+def test_validation_error_records_name_and_problems():
+    """The error stores name and problems and formats a joined message."""
+    err = QuantityValidationError("time", ["too big", "not finite"])
+    assert err.name == "time"
+    assert err.problems == ["too big", "not finite"]
+    assert "time" in str(err)
+    assert "too big" in str(err)
+    assert "not finite" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# Constraints: Range and Finite
+# ---------------------------------------------------------------------------
+
+
+def test_range_within_bounds_returns_none():
+    """Range.check returns None when all values are inside the bounds."""
+    assert Range(0.0, 10.0).check(5.0 * u.s, "time") is None
+
+
+def test_range_inclusive_bounds():
+    """Range bounds are inclusive at both ends."""
+    r = Range(0.0, 10.0)
+    assert r.check(0.0 * u.s, "time") is None
+    assert r.check(10.0 * u.s, "time") is None
+
+
+def test_range_out_of_bounds_returns_message():
+    """Range.check returns a message when a value is outside the bounds."""
+    msg = Range(0.0, 10.0).check(11.0 * u.s, "time")
+    assert msg is not None
+    assert "range" in msg
+
+
+def test_range_checks_every_element_of_array():
+    """Range.check fails if any element of an array is out of bounds."""
+    r = Range(0.0, 10.0)
+    assert r.check([1.0, 2.0, 3.0] * u.s, "time") is None
+    assert r.check([1.0, 20.0] * u.s, "time") is not None
+
+
+def test_finite_accepts_finite_values():
+    """Finite.check returns None for finite scalars and arrays."""
+    assert Finite().check(5.0 * u.s, "time") is None
+    assert Finite().check([1.0, 2.0] * u.s, "time") is None
+
+
+@pytest.mark.parametrize("bad", [np.nan, np.inf, -np.inf])
+def test_finite_rejects_non_finite(bad):
+    """Finite.check returns a message for NaN or infinite values."""
+    msg = Finite().check(bad * u.s, "time")
+    assert msg is not None
+    assert "non-finite" in msg
+
+
+def test_range_and_finite_satisfy_constraint_protocol():
+    """Range and Finite are runtime-checkable Constraint instances."""
+    assert isinstance(Range(0.0, 1.0), Constraint)
+    assert isinstance(Finite(), Constraint)
+
+
+# ---------------------------------------------------------------------------
+# Shape kinds
+# ---------------------------------------------------------------------------
+
+
+def test_scalar_shape_accepts_scalar_rejects_array():
+    """SCALAR passes scalars and fails arrays."""
+    assert SCALAR.check(5.0 * u.s, "time") is None
+    assert SCALAR.check([1.0, 2.0] * u.s, "time") is not None
+
+
+def test_array_shape_accepts_array_rejects_scalar():
+    """ARRAY passes arrays and fails scalars."""
+    assert ARRAY.check([1.0, 2.0] * u.s, "time") is None
+    assert ARRAY.check(5.0 * u.s, "time") is not None
+
+
+def test_any_shape_accepts_both():
+    """ANY_SHAPE imposes no restriction."""
+    assert ANY_SHAPE.check(5.0 * u.s, "time") is None
+    assert ANY_SHAPE.check([1.0, 2.0] * u.s, "time") is None
+
+
+def test_shape_singletons_satisfy_shapekind_protocol():
+    """The shape singletons are runtime-checkable ShapeKind instances."""
+    assert isinstance(SCALAR, ShapeKind)
+    assert isinstance(ARRAY, ShapeKind)
+    assert isinstance(ANY_SHAPE, ShapeKind)
+
+
+# ---------------------------------------------------------------------------
+# QuantitySpec dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_quantity_spec_defaults():
+    """A QuantitySpec has empty equivalencies and constraints by default."""
     spec = QuantitySpec("area", u.m**2)
-
     assert spec.name == "area"
-    assert spec.default == (u.m**2)
+    assert spec.default == u.m**2
     assert spec.equivalencies == []
     assert spec.constraints == ()
 
 
-@pytest.mark.parametrize("q", [0.010 * u.km**2, 10.0 * u.m**2])
-def test_check_quantity_valid(q):
-    """Test that check_quantity returns correct result for valid cases."""
+def test_quantity_spec_is_frozen():
+    """QuantitySpec is immutable (frozen dataclass)."""
+    spec = QuantitySpec("area", u.m**2)
+    with pytest.raises(Exception):
+        spec.name = "other"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Spec builder
+# ---------------------------------------------------------------------------
+
+
+def test_spec_build_returns_quantity_spec():
+    """Spec.build returns a QuantitySpec with the supplied identity."""
+    spec = Spec("gain", u.electron / u.adu).build()
+    assert isinstance(spec, QuantitySpec)
+    assert spec.name == "gain"
+    assert spec.default == u.electron / u.adu
+    assert spec.constraints == ()
+
+
+def test_spec_ranged_adds_range_constraint():
+    """Spec.ranged appends a Range constraint."""
+    spec = Spec("gain", u.electron / u.adu).ranged(0.1, 100.0).build()
+    assert len(spec.constraints) == 1
+    assert isinstance(spec.constraints[0], Range)
+    assert spec.constraints[0].vmin == 0.1
+    assert spec.constraints[0].vmax == 100.0
+
+
+def test_spec_finite_adds_finite_constraint():
+    """Spec.finite appends a Finite constraint."""
+    spec = Spec("time", u.s).finite().build()
+    assert len(spec.constraints) == 1
+    assert isinstance(spec.constraints[0], Finite)
+
+
+def test_spec_with_constraint_adds_custom_constraint():
+    """Spec.with_constraint appends an arbitrary constraint."""
+    custom = Range(1.0, 2.0)
+    spec = Spec("time", u.s).with_constraint(custom).build()
+    assert spec.constraints == (custom,)
+
+
+def test_spec_chaining_preserves_order():
+    """Chained builder calls accumulate constraints in call order."""
+    spec = Spec("time", u.s).ranged(0.0, 10.0).finite().build()
+    assert len(spec.constraints) == 2
+    assert isinstance(spec.constraints[0], Range)
+    assert isinstance(spec.constraints[1], Finite)
+
+
+def test_spec_builder_accepts_equivalencies():
+    """Spec forwards equivalencies to the produced QuantitySpec."""
+    equivs = u.dimensionless_angles()
+    spec = Spec("solid_angle", u.sr, equivs).build()
+    assert spec.equivalencies == equivs
+
+
+# ---------------------------------------------------------------------------
+# check_quantity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("q", [10.0 * u.m**2, 0.010 * u.km**2])
+def test_check_quantity_valid_returns_equal_value(q):
+    """check_quantity returns the same physical quantity for valid input."""
     assert u.isclose(check_quantity(q, AREA), q)
 
 
-@pytest.mark.parametrize(
-    "q,expected_error",
-    [
-        (10.0, TypeError),
-        (10.0 * u.m, ValueError),
-    ],
-)
-def test_check_quantity_invalid(q, expected_error):
-    """Test that check_quantity raises proper exception for invalid cases."""
-    with pytest.raises(expected_error):
-        check_quantity(q, AREA)
+def test_check_quantity_converts_to_canonical_unit():
+    """check_quantity converts the result to the spec's canonical unit."""
+    result = check_quantity(0.010 * u.km**2, AREA)
+    assert result.unit == u.m**2
+    assert result.value == pytest.approx(10000.0)
 
 
-def test_check_quantity_converts_to_default_unit():
-    """Test that a valid quantity is converted to the spec's default unit."""
-    assert check_quantity(0.010 * u.km**2, AREA).unit == (u.m**2)
+def test_check_quantity_rejects_non_quantity():
+    """A non-Quantity value raises TypeError."""
+    with pytest.raises(TypeError):
+        check_quantity(10.0, AREA)
 
 
-def test_range_constraint_aggregates_failures():
-    """Test that value-level constraints raise an aggregated error."""
+def test_check_quantity_rejects_non_spec():
+    """A non-QuantitySpec spec raises TypeError."""
+    with pytest.raises(TypeError):
+        check_quantity(10.0 * u.m**2, "not a spec")
+
+
+def test_check_quantity_rejects_incompatible_unit():
+    """An incompatible unit raises ValueError."""
+    with pytest.raises(ValueError):
+        check_quantity(10.0 * u.m, AREA)
+
+
+def test_check_quantity_honors_equivalencies():
+    """A spec's equivalencies enable otherwise-incompatible conversions."""
+    result = check_quantity(1.0 * u.rad, SOLID_ANGLE)
+    assert result.unit == u.sr
+
+
+def test_check_quantity_runs_value_constraints():
+    """A value violating a constraint raises QuantityValidationError."""
     spec = Spec("gain", u.electron / u.adu).ranged(0.1, 100.0).build()
-
     check_quantity(1.0 * u.electron / u.adu, spec)
     with pytest.raises(QuantityValidationError):
         check_quantity(1e3 * u.electron / u.adu, spec)
 
 
-def test_quantity_validation_error_is_value_error():
-    """Test that QuantityValidationError is catchable as ValueError."""
-    spec = Spec("time", u.s).ranged(0.0, 10.0).build()
+def test_check_quantity_aggregates_multiple_failures():
+    """Multiple constraint failures are collected into one error."""
+    spec = Spec("time", u.s).ranged(0.0, 10.0).finite().build()
+    with pytest.raises(QuantityValidationError) as excinfo:
+        check_quantity(np.inf * u.s, spec)
+    # inf is both out of range and non-finite -> two problems.
+    assert len(excinfo.value.problems) == 2
 
-    with pytest.raises(ValueError):
-        check_quantity(100.0 * u.s, spec)
 
-
-def test_check_quantity_scalar_shape():
-    """Test that the SCALAR shape rejects arrays and accepts scalars."""
+def test_check_quantity_scalar_shape_enforced():
+    """The SCALAR shape rejects arrays and accepts scalars."""
     check_quantity(5.0 * u.s, TIME, SCALAR)
     with pytest.raises(QuantityValidationError):
         check_quantity([1.0, 2.0] * u.s, TIME, SCALAR)
 
 
-def test_check_quantity_array_shape():
-    """Test that the ARRAY shape rejects scalars and accepts arrays."""
+def test_check_quantity_array_shape_enforced():
+    """The ARRAY shape rejects scalars and accepts arrays."""
     check_quantity([1.0, 2.0] * u.s, TIME, ARRAY)
     with pytest.raises(QuantityValidationError):
         check_quantity(5.0 * u.s, TIME, ARRAY)
+
+
+def test_check_quantity_shape_defaults_to_any():
+    """Omitting the shape argument allows both scalars and arrays."""
+    assert check_quantity(5.0 * u.s, TIME).isscalar
+    assert not check_quantity([1.0, 2.0] * u.s, TIME).isscalar
+
+
+def test_check_quantity_combines_value_and_shape_failures():
+    """Value-constraint and shape failures are aggregated together."""
+    spec = Spec("time", u.s).ranged(0.0, 10.0).build()
+    with pytest.raises(QuantityValidationError) as excinfo:
+        check_quantity([1.0, 20.0] * u.s, spec, SCALAR)
+    assert len(excinfo.value.problems) == 2
+
+
+# ---------------------------------------------------------------------------
+# _spec_from_annotated / _extract_spec
+# ---------------------------------------------------------------------------
+
+
+def test_spec_from_annotated_finds_spec():
+    """_spec_from_annotated pulls a QuantitySpec out of Annotated metadata."""
+    from typing import Annotated
+
+    annotation = Annotated[u.Quantity, AREA, Scalar]
+    assert _spec_from_annotated(annotation) is AREA
+
+
+def test_spec_from_annotated_returns_none_without_spec():
+    """_spec_from_annotated returns None when no QuantitySpec is present."""
+    from typing import Annotated
+
+    annotation = Annotated[u.Quantity, "meta"]
+    assert _spec_from_annotated(annotation) is None
+
+
+def test_spec_from_annotated_returns_none_for_plain_type():
+    """_spec_from_annotated returns None for a non-Annotated type."""
+    assert _spec_from_annotated(u.Quantity) is None
 
 
 @pytest.mark.parametrize(
@@ -88,12 +321,48 @@ def test_check_quantity_array_shape():
         (Area, AREA, ANY_SHAPE),
         (Area[Scalar], AREA, SCALAR),
         (Area[Array], AREA, ARRAY),
+        (Area[AnyShape], AREA, ANY_SHAPE),
+        (Time, TIME, ANY_SHAPE),
         (None, None, ANY_SHAPE),
         (Area[Scalar] | None, AREA, SCALAR),
     ],
 )
 def test_extract_spec(annotation, expected_spec, expected_shape):
-    """Test that _extract_spec returns the correct (spec, shape) pair."""
+    """_extract_spec resolves alias, shape marker, and union forms."""
     spec, shape = _extract_spec(annotation)
     assert spec == expected_spec
     assert shape is expected_shape
+
+
+def test_extract_spec_direct_annotated():
+    """_extract_spec handles a directly written Annotated hint."""
+    from typing import Annotated
+
+    spec, shape = _extract_spec(Annotated[u.Quantity, AREA])
+    assert spec is AREA
+    assert shape is ANY_SHAPE
+
+
+def test_extract_spec_no_spec_returns_none():
+    """_extract_spec returns (None, ANY_SHAPE) for an unrelated type."""
+    spec, shape = _extract_spec(int)
+    assert spec is None
+    assert shape is ANY_SHAPE
+
+
+# ---------------------------------------------------------------------------
+# Catalogue
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "spec,name,unit",
+    [
+        (AREA, "area", u.m**2),
+        (TIME, "time", u.s),
+    ],
+)
+def test_catalogue_specs(spec, name, unit):
+    """Catalogue constants carry the expected name and canonical unit."""
+    assert spec.name == name
+    assert spec.default == unit

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -1,23 +1,40 @@
+"""Tests for metroid.utils.validation."""
+
 import pytest
-from astropy import units as u
 
 from metroid.utils.validation import get_field_value
 
 
-def test_get_field_value_valid():
-    """Test that get_field_value returns correct result for valid cases."""
+def test_get_field_value_returns_value():
+    """A present field of the requested type is returned."""
     config = {"name": "value"}
-    assert "value" == get_field_value(config, "name", str)
+    assert get_field_value(config, "name", str) == "value"
 
 
-@pytest.mark.parametrize(
-    "config,key,typ,expected_exception",
-    [
-        ({"name": "value"}, "other", str, ValueError),
-        ({"name": "value"}, "name", int, TypeError),
-    ],
-)
-def test_get_field_value_invalid(config, key, typ, expected_exception):
-    """Test that get_field_value raises proper exception for invalid cases."""
-    with pytest.raises(expected_exception):
-        get_field_value(config, key, typ)
+def test_get_field_value_returns_numeric_value():
+    """A numeric field is returned when the type matches."""
+    config = {"radius": 4.0}
+    assert get_field_value(config, "radius", float) == 4.0
+
+
+def test_get_field_value_missing_field_raises_value_error():
+    """A missing field raises ValueError naming the field."""
+    with pytest.raises(ValueError):
+        get_field_value({"name": "value"}, "other", str)
+
+
+def test_get_field_value_wrong_type_raises_type_error():
+    """A value of the wrong type raises TypeError."""
+    with pytest.raises(TypeError):
+        get_field_value({"name": "value"}, "name", int)
+
+
+def test_get_field_value_non_string_name_raises_type_error():
+    """A non-string field name raises TypeError."""
+    with pytest.raises(TypeError):
+        get_field_value({"name": "value"}, 123, str)  # type: ignore[arg-type]
+
+
+def test_get_field_value_uses_isinstance_semantics():
+    """Type checking uses isinstance, so a bool satisfies an int request."""
+    assert get_field_value({"n": True}, "n", int) is True


### PR DESCRIPTION
Closes #36

## Summary

Replaces the accumulated, out-of-date unit test suite with a fresh, comprehensive set spanning the whole package. Tests were designed against the source implementation **in isolation** from the existing tests to avoid inheriting tech debt; existing code was reused only where a planned test coincided exactly (shared fixtures, the #19/#20 regression tests in `test_throughput.py`).

## Results

- **200 tests pass**, 0 failures.
- **99% line coverage** — the only uncovered lines are abstract-method `pass` stubs in `pupils.py` / `orbital_objects.py`, unreachable by design.
- No source-level bugs surfaced, so no follow-up defect issues were required.

## Coverage by area

- **`utils/`**
  - `test_quantities.py` — `Range`/`Finite` constraints, shape kinds, protocol conformance, `Spec` builder chaining, `check_quantity` aggregation of multiple failures, `_extract_spec`/`_spec_from_annotated` edge cases.
  - `test_decorators.py` — argument/return unit conversion, shape enforcement, `None`-skipping, metadata preservation, `validated_dataclass` unit/shape/frozen behavior.
  - `test_validation.py` — `get_field_value` present/missing/wrong-type/isinstance semantics.
- **top level**
  - `test_camera.py` — mapping interface, unit conversion, read-only bandpass mapping, component validation.
  - `test_observatory.py` — component validation, `get_photo_params` construction and exptime conversion.
- **`photometry/`**
  - `test_sed.py` — construction invariants, `for_ab_magnitudes` grid/scaling.
  - `test_photo_params.py` (new) — validated dataclass fields, defaults, frozen, bad units/shapes.
  - `test_conversions.py` — value/unit checks and type/unit validation for both conversion kernels.
  - `test_throughput.py` — magnitude scaling laws, int/bool handling, filter-ownership freezing invariant (#19), int-magnitude support (#20).
- **`profiles/`**
  - `test_pupils.py` — `from_config` registry dispatch, config immutability, areas, profile geometry.
  - `test_orbital_objects.py` — analytic orbital-mechanics checks, pixel-traversal time, `get_tracked_profile`, nadir-pointing projection paths.

## Verification

`pytest tests/` → 200 passed. `black tests/` clean.

Generated with AI

Co-Authored-By: SLAC AI